### PR TITLE
Fix .cache folder permission in docker

### DIFF
--- a/.docker/.env
+++ b/.docker/.env
@@ -1,6 +1,7 @@
 UID=1000
 GID=1000
+UNAME=docker_dev
 HOST_SPIRES_DATA_DIR=~/data/oxford_spires_dataset
 HOME_DIR=/home
-SPIRES_DIR=${HOME_DIR}/oxford_spires_dataset
+SPIRES_DIR=${HOME_DIR}/${UNAME}/oxford_spires_dataset
 SPIRES_DATA_DIR=${SPIRES_DIR}/data

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -137,7 +137,7 @@ ENV UNAME=docker_dev
 RUN addgroup --gid $GID $UNAME
 RUN adduser --disabled-password --gecos '' --uid $UID --gid $GID $UNAME
 
-ARG SPIRES_DIR=/home/oxford_spires_dataset
+ARG SPIRES_DIR=/home/${UNAME}/oxford_spires_dataset
 WORKDIR ${SPIRES_DIR}
 
 COPY ./requirements.txt ${SPIRES_DIR}/requirements.txt
@@ -151,7 +151,7 @@ RUN mkdir /home/${UNAME}/.cache
 
 # Make the outputs of the container match the host
 
-RUN chown -R ${UID}:${GID} ${SPIRES_DIR}
+RUN chown -R ${UID}:${GID} /home/${UNAME}
 USER ${UNAME}
 RUN echo "PS1='${debian_chroot:+($debian_chroot)}\[\033[01;33m\]\u@docker-\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> ~/.bashrc
 RUN echo "alias recon_benchmark=\"python ${SPIRES_DIR}/scripts/reconstruction_benchmark/main.py\"" >> ~/.bashrc


### PR DESCRIPTION
This pull request mainly address the issue introduced from #11 , specifically c134e50. This creates a `/home/docker_dev/.cache` which belongs to root and `chmod` in the Dockerfile doesn't solve it.

A simple solution is just to create the `.cache` in the Dockerfile.

Other changes include reorganising the folder so that the workdirectory is now `/home/docker_dev/oxford_spires_dataset` instead of `/home/oxford_spires_dataset`. This just make it under the normal user directory, which is more natural.