### PR TITLE
Bump Ruff to 0.11.4

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -9,5 +9,5 @@ jobs:
         with:
           version: "0.11.4"
           args: "--version"
-      - run: ruff check
-      - run: ruff format --check
+      - run: ruff check --config pyproject.toml
+      - run: ruff format --check --config pyproject.toml

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,7 +4,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
           version: "0.11.4"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,7 +4,10 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/checkout@v3
+      - uses: astral-sh/ruff-action@v3
         with:
-          version: 0.8.1
+          version: "0.11.4"
+          args: "--version"
+      - run: ruff check
+      - run: ruff format --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,11 @@ repos:
       # Run the linter.
       - id: ruff
         types_or: [python, pyi, jupyter]
-        args: [ --fix ]
+        args: [--fix, --config, pyproject.toml]
       # Run the formatter.
       - id: ruff-format
         types_or: [python, pyi, jupyter]
+        args: [--config, pyproject.toml]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8  # Replace with the latest version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.1
+    rev: v0.11.4
     hooks:
       # Run the linter.
       - id: ruff

--- a/oxford_spires_utils/sensor.py
+++ b/oxford_spires_utils/sensor.py
@@ -40,9 +40,9 @@ class Camera:
     def __post_init__(self):
         assert self.camera_model in supported_camera_models, f"Camera model {self.camera_model} not supported"
         assert len(self.intrinsics) == 4, f"Expected 4 intrinsics, got {len(self.intrinsics)}"
-        assert (
-            len(self.extra_params) == expected_num_extra_param[self.camera_model]
-        ), f"Expected {expected_num_extra_param[self.camera_model]} extra params, got {len(self.extra_params)}"
+        assert len(self.extra_params) == expected_num_extra_param[self.camera_model], (
+            f"Expected {expected_num_extra_param[self.camera_model]} extra params, got {len(self.extra_params)}"
+        )
         self.T_cam_lidar_overwrite = (
             get_transformation_matrix(self.T_cam_lidar_t_xyz_q_xyzw_overwrite)
             if len(self.T_cam_lidar_t_xyz_q_xyzw_overwrite) > 0

--- a/oxford_spires_utils/trajectory/file_interfaces/nerf.py
+++ b/oxford_spires_utils/trajectory/file_interfaces/nerf.py
@@ -163,14 +163,14 @@ class NeRFTrajWriter(BasicTrajWriter):
         @params template_meta: template json file
         """
         meta = deepcopy(template_meta)
-        assert (
-            len(meta["frames"]) == pose.num_poses
-        ), "Number of frames in template file does not match the number of poses"
+        assert len(meta["frames"]) == pose.num_poses, (
+            "Number of frames in template file does not match the number of poses"
+        )
         for i in range(pose.num_poses):
             # assume order of frames in template file is the same as the order of poses
-            assert pose.timestamps[i] == NeRFTrajUtils.get_t_float128_from_fname(
-                meta["frames"][i]["file_path"]
-            ), "Timestamps of frames in template file does not match the timestamps of poses"
+            assert pose.timestamps[i] == NeRFTrajUtils.get_t_float128_from_fname(meta["frames"][i]["file_path"]), (
+                "Timestamps of frames in template file does not match the timestamps of poses"
+            )
             meta["frames"][i]["transform_matrix"] = pose.poses_se3[i].tolist()
         return meta
 

--- a/oxford_spires_utils/trajectory/file_interfaces/timestamp.py
+++ b/oxford_spires_utils/trajectory/file_interfaces/timestamp.py
@@ -74,9 +74,9 @@ class TimeStamp:
 
         t_float128 = np.float128(self.t_string)
         # check
-        assert (
-            TimeStamp.get_string_from_t_float128(t_float128) == self.t_string
-        ), f"Precision Lost: t_float128 {t_float128} should be {self.t_string}"
+        assert TimeStamp.get_string_from_t_float128(t_float128) == self.t_string, (
+            f"Precision Lost: t_float128 {t_float128} should be {self.t_string}"
+        )
 
         return t_float128
 
@@ -109,9 +109,9 @@ class TimeStamp:
         @param f: np.float128
         @return: (sec, nsec), both str, nsec is 9 digits
         """
-        assert isinstance(
-            t_float128, np.float128
-        ), f"t_float128 should be of type np.float128, but is {type(t_float128)}"
+        assert isinstance(t_float128, np.float128), (
+            f"t_float128 should be of type np.float128, but is {type(t_float128)}"
+        )
         sec, nsec = str(t_float128).split(".")
         nsec = nsec.ljust(NSECONDS_DIGITS, "0")
         assert len(nsec) == NSECONDS_DIGITS, f"nsec {nsec} should be {NSECONDS_DIGITS} digits"

--- a/oxford_spires_utils/trajectory/file_interfaces/tum.py
+++ b/oxford_spires_utils/trajectory/file_interfaces/tum.py
@@ -74,9 +74,9 @@ class TUMTrajReader(BasicTrajReader):
                 print("skipping lines with wrong prefix or suffix")
                 continue
             t_float128 = TimeStamp(t_string=fname[len(prefix) : len(fname) - len(suffix)]).t_float128
-            assert (
-                TimeStamp.get_string_from_t_float128(t_float128) == fname[len(prefix) : len(fname) - len(suffix)]
-            ), f"loss of precision in timestamp: before {fname[len(prefix) : len(fname)-len(suffix)]}; after {t_float}"
+            assert TimeStamp.get_string_from_t_float128(t_float128) == fname[len(prefix) : len(fname) - len(suffix)], (
+                f"loss of precision in timestamp: before {fname[len(prefix) : len(fname) - len(suffix)]}; after {t_float}"
+            )
             time_stamp.append(t_float128)
             translation = splited[1:4]
             quaternion_xyzw = splited[4:8]

--- a/oxford_spires_utils/trajectory/file_interfaces/vilens_slam.py
+++ b/oxford_spires_utils/trajectory/file_interfaces/vilens_slam.py
@@ -31,6 +31,7 @@ class VilensSlamTrajReader(BasicTrajReader):
         quat_wxyz = np.roll(quat_xyzw, 1, axis=1)  # xyzw -> wxyz
         return evo.core.trajectory.PoseTrajectory3D(xyz, quat_wxyz, timestamps=timestamps)
 
+
 class VilensSlamTrajWriter(BasicTrajWriter):
     """
     write VILENS SLAM trajectory format file (poses.csv)
@@ -41,7 +42,7 @@ class VilensSlamTrajWriter(BasicTrajWriter):
 
     def write_file(self, pose):
         """
-        this is used for CSV style trajectory file 
+        this is used for CSV style trajectory file
         @param self.file_path: path to save the file
         @param pose: PoseTrajectory3D from evo
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ evo>=1.29.0
 pytransform3d>=3.5.0
 huggingface_hub>=0.25.1
 ruff==0.11.4
+pre-commit==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pye57>=0.4.13
 evo>=1.29.0
 pytransform3d>=3.5.0
 huggingface_hub>=0.25.1
+ruff==0.11.4

--- a/scripts/localisation_benchmark/colmap.py
+++ b/scripts/localisation_benchmark/colmap.py
@@ -10,8 +10,7 @@ from oxford_spires_utils.trajectory.file_interfaces import NeRFTrajReader, TUMTr
 from oxford_spires_utils.trajectory.json_handler import JsonHandler
 
 
-def convert_to_tum (path_to_output, path_to_sec):
-    
+def convert_to_tum(path_to_output, path_to_sec):
     print("Convert from JSON format to TUM!!")
 
     # Remove other cameras
@@ -28,44 +27,46 @@ def convert_to_tum (path_to_output, path_to_sec):
     print("*********************************************************")
 
 
-def get_sec_list (dataset_dir, flag_is_all=True):
+def get_sec_list(dataset_dir, flag_is_all=True):
     if flag_is_all:
         list_sec = os.listdir(dataset_dir)
     else:
         list_sec = [
-                    "2024-03-12-keble-college-02",
-                    "2024-03-12-keble-college-03",
-                    "2024-03-12-keble-college-04",
-                    "2024-03-12-keble-college-05",
-                    "2024-03-13-observatory-quarter-01",
-                    "2024-03-13-observatory-quarter-02",
-                    "2024-03-14-blenheim-palace-01",
-                    "2024-03-14-blenheim-palace-02",
-                    "2024-03-14-blenheim-palace-05",
-                    "2024-03-18-christ-church-01",
-                    "2024-03-18-christ-church-02",
-                    "2024-03-18-christ-church-03",
-                    "2024-03-20-christ-church-05",
-                    "2024-05-20-bodleian-library-02",
-                    "2024-05-20-bodleian-library-03",
-                    "2024-05-20-bodleian-library-04",
-                    "2024-05-20-bodleian-library-05"
-                    ]
+            "2024-03-12-keble-college-02",
+            "2024-03-12-keble-college-03",
+            "2024-03-12-keble-college-04",
+            "2024-03-12-keble-college-05",
+            "2024-03-13-observatory-quarter-01",
+            "2024-03-13-observatory-quarter-02",
+            "2024-03-14-blenheim-palace-01",
+            "2024-03-14-blenheim-palace-02",
+            "2024-03-14-blenheim-palace-05",
+            "2024-03-18-christ-church-01",
+            "2024-03-18-christ-church-02",
+            "2024-03-18-christ-church-03",
+            "2024-03-20-christ-church-05",
+            "2024-05-20-bodleian-library-02",
+            "2024-05-20-bodleian-library-03",
+            "2024-05-20-bodleian-library-04",
+            "2024-05-20-bodleian-library-05",
+        ]
     return list_sec
 
-def evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, method):
-    
+
+def evaluation_ape_rmse(path_to_gt, path_traj, dataset_dir, method):
     print("RUNNING VILENS EVALUATION ...")
 
-    output = run_command("evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False)
-    
+    output = run_command(
+        "evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False
+    )
+
     rmse = -1
     for line in output.stdout:
         print(line, end="")
         if "rmse" in line:
-            numbers = re.findall('\d+\.\d+|\d+', line)
+            numbers = re.findall("\d+\.\d+|\d+", line)
             rmse = numbers[0]
-    
+
     logging.basicConfig(filename=dataset_dir + "results.log", filemode="a", level=logging.INFO)
     logging.info(path_to_sec)
     logging.info("APE - RMSE result ({}): {}".format(method, rmse))
@@ -73,35 +74,34 @@ def evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, method):
 
     return rmse
 
-def create_output_folder (path_to_sec):
+
+def create_output_folder(path_to_sec):
     path_to_output = path_to_sec + "/output" + "/colmap/"
     # if not os.path.exists(path_to_output):
     #         os.makedirs(path_to_output)
     return path_to_output
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     # -------------------------------------------------------------------------------- #
     # TODO: get path from arg an define folders in the future class.
     package_dir = "/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_dataset"
-    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/" 
+    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/"
     flag_is_all = False
     # -------------------------------------------------------------------------------- #
 
-    list_sec = get_sec_list (dataset_dir, flag_is_all)
-    
-    print('Total sequence folders: ' + str(len(list_sec)))
-    
+    list_sec = get_sec_list(dataset_dir, flag_is_all)
+
+    print("Total sequence folders: " + str(len(list_sec)))
+
     # Print list of sequences
     for sec in list_sec:
-        
         path_to_sec = dataset_dir + sec
         path_to_gt = path_to_sec + "/processed/trajectory/gt-tum.txt"
 
-        path_to_output = create_output_folder (path_to_sec)
+        path_to_output = create_output_folder(path_to_sec)
 
-        convert_to_tum (path_to_output, path_to_sec)
+        convert_to_tum(path_to_output, path_to_sec)
 
         path_traj = path_to_sec + "/output" + "/colmap-tum.txt"
-        rmse = evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, "COLMAP")
-    
+        rmse = evaluation_ape_rmse(path_to_gt, path_traj, dataset_dir, "COLMAP")

--- a/scripts/localisation_benchmark/fast_lio_slam.py
+++ b/scripts/localisation_benchmark/fast_lio_slam.py
@@ -14,58 +14,57 @@ sys.path.append("/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_da
 from oxford_spires_utils.bash_command import run_command
 
 
-def run_fast_lio_slam (path_to_rosbag, path_to_output):
-    
+def run_fast_lio_slam(path_to_rosbag, path_to_output):
     server = libtmux.Server()
-    server.cmd('new-session', '-d', '-P', '-F#{session_id}')
+    server.cmd("new-session", "-d", "-P", "-F#{session_id}")
     session = server.sessions[0]
     window_1 = session.new_window(attach=False, window_name="launch fast_lio_slam")
     window_2 = session.new_window(attach=False, window_name="launch aloam_velodyne")
-    window_3 = session.new_window(attach=False, window_name="rosbag") 
+    window_3 = session.new_window(attach=False, window_name="rosbag")
     pane_1 = window_1.panes.get()
     pane_2 = window_2.panes.get()
     pane_3 = window_3.panes.get()
 
-    pane_2.send_keys('cd ~/oxford-lab/lidar_slam_ws/')
-    pane_2.send_keys('source devel/setup.bash')
-    pane_2.send_keys('roslaunch aloam_velodyne aloam_hesai.launch arg_save_directory:={}'.format(path_to_output))
+    pane_2.send_keys("cd ~/oxford-lab/lidar_slam_ws/")
+    pane_2.send_keys("source devel/setup.bash")
+    pane_2.send_keys("roslaunch aloam_velodyne aloam_hesai.launch arg_save_directory:={}".format(path_to_output))
     print("SC-PGO launched!! - mapping_hesai.launch")
 
     time.sleep(5)
 
-    pane_1.send_keys('cd ~/oxford-lab/lidar_slam_ws/')
-    pane_1.send_keys('source devel/setup.bash')
-    pane_1.send_keys('roslaunch fast_lio mapping_hesai.launch')
+    pane_1.send_keys("cd ~/oxford-lab/lidar_slam_ws/")
+    pane_1.send_keys("source devel/setup.bash")
+    pane_1.send_keys("roslaunch fast_lio mapping_hesai.launch")
     print("Fast-LIO-SLAM launched!! - mapping_hesai.launch")
 
     time.sleep(5)
-    
-    pane_3.send_keys('cd {}'.format(path_to_rosbag))
-    pane_3.send_keys('rosbag play *.bag --clock')
+
+    pane_3.send_keys("cd {}".format(path_to_rosbag))
+    pane_3.send_keys("rosbag play *.bag --clock")
     print("Starting rosbag files in {}".format(path_to_rosbag))
 
     # Check if the rosbag is "Done."
-    t  = time.time()
+    t = time.time()
     flag_end = False
-    while (1):
+    while 1:
         pane_3.clear()
         time.sleep(1)
         cap_curr = pane_3.capture_pane()
         for line in cap_curr:
             if "[RUNNING]" in line:
-                t  = time.time()
+                t = time.time()
                 print(line)
                 sys.stdout.write("\033[F")
-            if 'Done.' in line:
-                t  = time.time()
+            if "Done." in line:
+                t = time.time()
                 flag_end = True
                 sys.stdout.write("\033[K")
-                print('Done.') 
+                print("Done.")
                 break
         if flag_end:
             break
-        if (time.time() - t) > 60.0: # To avoid infinite
-            print('Timeout!!')
+        if (time.time() - t) > 60.0:  # To avoid infinite
+            print("Timeout!!")
             break
 
     print("PROCESS FINISHED!!")
@@ -75,14 +74,17 @@ def run_fast_lio_slam (path_to_rosbag, path_to_output):
     server.kill()
 
 
-def convert_to_tum (path_to_output, path_to_sec):
-    
+def convert_to_tum(path_to_output, path_to_sec):
     print("Convert from KITTI format to TUM!!")
 
     pose_path = file_interface.read_kitti_poses_file(path_to_output + "optimized_poses.txt")
     raw_timestamps_mat = file_interface.csv_read_matrix(path_to_output + "times.txt")
-    error_msg = ("timestamp file must have one column of timestamps and same number of rows as the KITTI poses file")
-    if len(raw_timestamps_mat) > 0 and len(raw_timestamps_mat[0]) != 1 or len(raw_timestamps_mat) != pose_path.num_poses:
+    error_msg = "timestamp file must have one column of timestamps and same number of rows as the KITTI poses file"
+    if (
+        len(raw_timestamps_mat) > 0
+        and len(raw_timestamps_mat[0]) != 1
+        or len(raw_timestamps_mat) != pose_path.num_poses
+    ):
         raise file_interface.FileInterfaceException(error_msg)
     try:
         timestamps_mat = np.array(raw_timestamps_mat).astype(float)
@@ -97,81 +99,83 @@ def convert_to_tum (path_to_output, path_to_sec):
     print("*********************************************************")
 
 
-def eval_fast_lio_slam (path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir):
-    
+def eval_fast_lio_slam(path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir):
     path_traj = path_to_sec + "/output_slam" + "/fast_lio_tum.txt"
-    output = run_command("evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False)
-    
+    output = run_command(
+        "evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False
+    )
+
     rmse = -1
     for line in output.stdout:
         print(line, end="")
         if "rmse" in line:
-            numbers = re.findall('\d+\.\d+|\d+', line)
+            numbers = re.findall("\d+\.\d+|\d+", line)
             rmse = numbers[0]
-    
+
     logging.basicConfig(filename=dataset_dir + "results.log", filemode="a", level=logging.INFO)
     logging.info(path_to_sec)
     logging.info("APE - RMSE result (Fast_LIO-SLAM): {}".format(rmse))
     print("RMSE added to log: {}".format(rmse))
 
-def create_output_folder (path_to_sec):
+
+def create_output_folder(path_to_sec):
     path_to_output = path_to_sec + "/output_slam" + "/fastlio_raw_output/"
     if not os.path.exists(path_to_output):
-            os.makedirs(path_to_output)
+        os.makedirs(path_to_output)
     return path_to_output
 
-def get_sec_list (dataset_dir, flag_is_all=True):
+
+def get_sec_list(dataset_dir, flag_is_all=True):
     if flag_is_all:
         list_sec = os.listdir(dataset_dir)
     else:
         list_sec = [
-                    "2024-03-12-keble-college-02",
-                    "2024-03-12-keble-college-03",
-                    "2024-03-12-keble-college-04",
-                    "2024-03-12-keble-college-05",
-                    "2024-03-13-observatory-quarter-01",
-                    "2024-03-13-observatory-quarter-02",
-                    "2024-03-14-blenheim-palace-01",
-                    "2024-03-14-blenheim-palace-02",
-                    "2024-03-14-blenheim-palace-05",
-                    "2024-03-18-christ-church-01",
-                    "2024-03-18-christ-church-02",
-                    "2024-03-18-christ-church-03",
-                    "2024-03-20-christ-church-05",
-                    "2024-05-20-bodleian-library-02",
-                    "2024-05-20-bodleian-library-03",
-                    "2024-05-20-bodleian-library-04",
-                    "2024-05-20-bodleian-library-05"
-                    ]
+            "2024-03-12-keble-college-02",
+            "2024-03-12-keble-college-03",
+            "2024-03-12-keble-college-04",
+            "2024-03-12-keble-college-05",
+            "2024-03-13-observatory-quarter-01",
+            "2024-03-13-observatory-quarter-02",
+            "2024-03-14-blenheim-palace-01",
+            "2024-03-14-blenheim-palace-02",
+            "2024-03-14-blenheim-palace-05",
+            "2024-03-18-christ-church-01",
+            "2024-03-18-christ-church-02",
+            "2024-03-18-christ-church-03",
+            "2024-03-20-christ-church-05",
+            "2024-05-20-bodleian-library-02",
+            "2024-05-20-bodleian-library-03",
+            "2024-05-20-bodleian-library-04",
+            "2024-05-20-bodleian-library-05",
+        ]
     return list_sec
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     # -------------------------------------------------------------------------------- #
     # TODO: get path from arg an define folders in the future class.
     package_dir = "/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_dataset"
-    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/" 
+    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/"
     flag_is_all = False
     # -------------------------------------------------------------------------------- #
 
-    list_sec = get_sec_list (dataset_dir, flag_is_all)
-    
-    print('Total sequence folders: ' + str(len(list_sec)))
-    
+    list_sec = get_sec_list(dataset_dir, flag_is_all)
+
+    print("Total sequence folders: " + str(len(list_sec)))
+
     # Print list of sequences
     for sec in list_sec:
-
         path_to_sec = dataset_dir + sec
-        path_to_rosbag = "/home/mice85/data/" + sec + "/rosbag/" #path_to_sec + "/rosbag/"
+        path_to_rosbag = "/home/mice85/data/" + sec + "/rosbag/"  # path_to_sec + "/rosbag/"
         path_to_gt = path_to_sec + "/ground_truth_traj/gt_lidar.txt"
-        path_to_output = create_output_folder (path_to_sec)
+        path_to_output = create_output_folder(path_to_sec)
 
-        run_fast_lio_slam (path_to_rosbag, path_to_output)
+        run_fast_lio_slam(path_to_rosbag, path_to_output)
 
         time.sleep(5)
 
-        convert_to_tum (path_to_output, path_to_sec)
+        convert_to_tum(path_to_output, path_to_sec)
 
-        eval_fast_lio_slam (path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir)
+        eval_fast_lio_slam(path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir)
 
         # break

--- a/scripts/localisation_benchmark/immesh.py
+++ b/scripts/localisation_benchmark/immesh.py
@@ -11,62 +11,59 @@ sys.path.append("/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_da
 from oxford_spires_utils.bash_command import run_command
 
 
-def run_immesh (path_to_rosbag, path_to_output):
-    
+def run_immesh(path_to_rosbag, path_to_output):
     server = libtmux.Server()
-    server.cmd('new-session', '-d', '-P', '-F#{session_id}')
+    server.cmd("new-session", "-d", "-P", "-F#{session_id}")
     session = server.sessions[0]
     window_1 = session.new_window(attach=False, window_name="launch immesh")
-    window_2 = session.new_window(attach=False, window_name="rosbag play") 
+    window_2 = session.new_window(attach=False, window_name="rosbag play")
     window_3 = session.new_window(attach=False, window_name="rosbag record")
     pane_1 = window_1.panes.get()
     pane_2 = window_2.panes.get()
     pane_3 = window_3.panes.get()
-    
-    pane_1.send_keys('cd ~/oxford-lab/lidar_slam_ws/')
-    pane_1.send_keys('source devel/setup.bash')
-    pane_1.send_keys('roslaunch ImMesh mapping_spire.launch')
+
+    pane_1.send_keys("cd ~/oxford-lab/lidar_slam_ws/")
+    pane_1.send_keys("source devel/setup.bash")
+    pane_1.send_keys("roslaunch ImMesh mapping_spire.launch")
     print("ImMesh launched!! - roslaunch ImMesh mapping_spire.launch")
-    
-    pane_2.send_keys('cd {}'.format(path_to_rosbag))
-    pane_2.send_keys('rosbag play *.bag --clock')
+
+    pane_2.send_keys("cd {}".format(path_to_rosbag))
+    pane_2.send_keys("rosbag play *.bag --clock")
     print("Starting rosbag files in {}".format(path_to_rosbag))
 
-    pane_3.send_keys('cd {}'.format(path_to_output))
-    pane_3.send_keys('rosbag record -O immesh_path.bag /path __name:=immesh_path')
+    pane_3.send_keys("cd {}".format(path_to_output))
+    pane_3.send_keys("rosbag record -O immesh_path.bag /path __name:=immesh_path")
     print("Rosbag record in {}".format(path_to_output))
-    
 
     # Check if the rosbag is "Done."
-    t  = time.time()
+    t = time.time()
     flag_end = False
-    while (1):
+    while 1:
         pane_2.clear()
         time.sleep(1)
         cap_curr = pane_2.capture_pane()
         for line in cap_curr:
             if "[RUNNING]" in line:
-                t  = time.time()
+                t = time.time()
                 print(line)
                 sys.stdout.write("\033[F")
-            if 'Done.' in line:
-                t  = time.time()
+            if "Done." in line:
+                t = time.time()
                 flag_end = True
                 sys.stdout.write("\033[K")
-                print('Done.') 
+                print("Done.")
                 break
         if flag_end:
             break
-        if (time.time() - t) > 60.0: # To avoid infinite
-            print('Timeout!!')
+        if (time.time() - t) > 60.0:  # To avoid infinite
+            print("Timeout!!")
             break
-    
+
     run_command("rosnode kill /immesh_path", print_output=True)
 
     time.sleep(3)
-    
-    if os.path.exists("{}/immesh_path.bag.active".format(path_to_output)):
 
+    if os.path.exists("{}/immesh_path.bag.active".format(path_to_output)):
         run_command("rosbag reindex {}/immesh_path.bag.active".format(path_to_output), print_output=True)
 
         old_file = os.path.join(path_to_output, "immesh_path.bag.active")
@@ -80,49 +77,51 @@ def run_immesh (path_to_rosbag, path_to_output):
 
     server.kill()
 
-def convert_to_tum (path_to_output):
 
+def convert_to_tum(path_to_output):
     print("Convert from ROS /path format to TUM!!")
-    
+
     server = libtmux.Server()
-    server.cmd('new-session', '-d', '-P', '-F#{session_id}')
+    server.cmd("new-session", "-d", "-P", "-F#{session_id}")
     session = server.sessions[0]
     window_1 = session.new_window(attach=False, window_name="launch bag_to_traj")
-    window_2 = session.new_window(attach=False, window_name="rosbag play") 
+    window_2 = session.new_window(attach=False, window_name="rosbag play")
     pane_1 = window_1.panes.get()
     pane_2 = window_2.panes.get()
-    
-    pane_1.send_keys('cd ~/oxford-lab/oxford_ws/')
-    pane_1.send_keys('source devel/setup.bash')
-    pane_1.send_keys('roslaunch bag_to_traj bag_to_traj.launch arg_outfile_path:={}/immesh_tum.txt'.format(path_to_output))
+
+    pane_1.send_keys("cd ~/oxford-lab/oxford_ws/")
+    pane_1.send_keys("source devel/setup.bash")
+    pane_1.send_keys(
+        "roslaunch bag_to_traj bag_to_traj.launch arg_outfile_path:={}/immesh_tum.txt".format(path_to_output)
+    )
     print("bag_to_traj launched!! - roslaunch bag_to_traj bag_to_traj.launch")
-    
-    pane_2.send_keys('cd {}'.format(path_to_output))
-    pane_2.send_keys('rosbag play *.bag --clock')
+
+    pane_2.send_keys("cd {}".format(path_to_output))
+    pane_2.send_keys("rosbag play *.bag --clock")
     print("Starting rosbag files in {}".format(path_to_output))
 
     # Check if the rosbag is "Done."
-    t  = time.time()
+    t = time.time()
     flag_end = False
-    while (1):
+    while 1:
         pane_2.clear()
         time.sleep(1)
         cap_curr = pane_2.capture_pane()
         for line in cap_curr:
             if "[RUNNING]" in line:
-                t  = time.time()
+                t = time.time()
                 print(line)
                 sys.stdout.write("\033[F")
-            if 'Done.' in line:
-                t  = time.time()
+            if "Done." in line:
+                t = time.time()
                 flag_end = True
                 sys.stdout.write("\033[K")
-                print('Done.') 
+                print("Done.")
                 break
         if flag_end:
             break
-        if (time.time() - t) > 60.0: # To avoid infinite
-            print('Timeout!!')
+        if (time.time() - t) > 60.0:  # To avoid infinite
+            print("Timeout!!")
             break
 
     old_file = os.path.join(path_to_output, "immesh_tum.txt")
@@ -135,84 +134,86 @@ def convert_to_tum (path_to_output):
 
     server.kill()
 
-def create_output_folder (path_to_sec):
+
+def create_output_folder(path_to_sec):
     path_to_output = path_to_sec + "/output_slam" + "/ImMesh_raw_output"
     if not os.path.exists(path_to_output):
-            os.makedirs(path_to_output)
+        os.makedirs(path_to_output)
     return path_to_output
 
-def eval_immesh (path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir):
 
+def eval_immesh(path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir):
     path_traj = os.path.join(path_to_sec + "/output_slam", "immesh_tum.txt")
-    output = run_command("evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False)
-    
+    output = run_command(
+        "evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False
+    )
+
     rmse = -1
     for line in output.stdout:
         print(line, end="")
         if "rmse" in line:
-            numbers = re.findall('\d+\.\d+|\d+', line)
+            numbers = re.findall("\d+\.\d+|\d+", line)
             rmse = numbers[0]
-    
+
     logging.basicConfig(filename=dataset_dir + "results.log", filemode="a", level=logging.INFO)
     logging.info(path_to_sec)
     logging.info("APE - RMSE result (ImMesh): {}".format(rmse))
     print("RMSE added to log: {}".format(rmse))
 
 
-def get_sec_list (dataset_dir, flag_is_all=True):
+def get_sec_list(dataset_dir, flag_is_all=True):
     if flag_is_all:
         list_sec = os.listdir(dataset_dir)
     else:
         list_sec = [
-                    "2024-03-12-keble-college-02",
-                    "2024-03-12-keble-college-03",
-                    "2024-03-12-keble-college-04",
-                    "2024-03-12-keble-college-05",
-                    "2024-03-13-observatory-quarter-01",
-                    "2024-03-13-observatory-quarter-02",
-                    "2024-03-14-blenheim-palace-01",
-                    "2024-03-14-blenheim-palace-02",
-                    "2024-03-14-blenheim-palace-05",
-                    "2024-03-18-christ-church-01",
-                    "2024-03-18-christ-church-02",
-                    "2024-03-18-christ-church-03",
-                    "2024-03-20-christ-church-05",
-                    "2024-05-20-bodleian-library-02",
-                    "2024-05-20-bodleian-library-03",
-                    "2024-05-20-bodleian-library-04",
-                    "2024-05-20-bodleian-library-05"
-                    ]
+            "2024-03-12-keble-college-02",
+            "2024-03-12-keble-college-03",
+            "2024-03-12-keble-college-04",
+            "2024-03-12-keble-college-05",
+            "2024-03-13-observatory-quarter-01",
+            "2024-03-13-observatory-quarter-02",
+            "2024-03-14-blenheim-palace-01",
+            "2024-03-14-blenheim-palace-02",
+            "2024-03-14-blenheim-palace-05",
+            "2024-03-18-christ-church-01",
+            "2024-03-18-christ-church-02",
+            "2024-03-18-christ-church-03",
+            "2024-03-20-christ-church-05",
+            "2024-05-20-bodleian-library-02",
+            "2024-05-20-bodleian-library-03",
+            "2024-05-20-bodleian-library-04",
+            "2024-05-20-bodleian-library-05",
+        ]
     return list_sec
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     # -------------------------------------------------------------------------------- #
     # TODO: get path from arg an define folders in the future class.
     package_dir = "/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_dataset"
-    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/" 
+    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/"
     flag_is_all = False
     # -------------------------------------------------------------------------------- #
 
-    list_sec = get_sec_list (dataset_dir, flag_is_all)
-    
-    print('Total sequence folders: ' + str(len(list_sec)))
-    
+    list_sec = get_sec_list(dataset_dir, flag_is_all)
+
+    print("Total sequence folders: " + str(len(list_sec)))
+
     # Print list of sequences
     for sec in list_sec:
-
         path_to_sec = dataset_dir + sec
-        path_to_rosbag = "/home/mice85/data/" + sec + "/rosbag/" #path_to_sec + "/rosbag/"
+        path_to_rosbag = "/home/mice85/data/" + sec + "/rosbag/"  # path_to_sec + "/rosbag/"
         path_to_gt = path_to_sec + "/ground_truth_traj/gt_lidar.txt"
-        path_to_output = create_output_folder (path_to_sec)
+        path_to_output = create_output_folder(path_to_sec)
 
-        run_immesh (path_to_rosbag, path_to_output)
-
-        time.sleep(5)
-
-        convert_to_tum (path_to_output)
+        run_immesh(path_to_rosbag, path_to_output)
 
         time.sleep(5)
 
-        eval_immesh (path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir)
+        convert_to_tum(path_to_output)
+
+        time.sleep(5)
+
+        eval_immesh(path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir)
 
         # break

--- a/scripts/localisation_benchmark/sc_lio_sam.py
+++ b/scripts/localisation_benchmark/sc_lio_sam.py
@@ -14,49 +14,48 @@ sys.path.append("/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_da
 from oxford_spires_utils.bash_command import run_command
 
 
-def run_sc_lio_sam (path_to_rosbag, path_to_output):
-    
+def run_sc_lio_sam(path_to_rosbag, path_to_output):
     server = libtmux.Server()
-    server.cmd('new-session', '-d', '-P', '-F#{session_id}')
+    server.cmd("new-session", "-d", "-P", "-F#{session_id}")
     session = server.sessions[0]
     window_1 = session.new_window(attach=False, window_name="launch sc_lio_sam")
-    window_2 = session.new_window(attach=False, window_name="rosbag") 
+    window_2 = session.new_window(attach=False, window_name="rosbag")
     pane_1 = window_1.panes.get()
     pane_2 = window_2.panes.get()
 
-    pane_1.send_keys('cd ~/oxford-lab/lidar_slam_ws/')
-    pane_1.send_keys('source devel/setup.bash')
-    pane_1.send_keys('roslaunch lio_sam run_hesai.launch arg_savePCDDirectory:={}'.format(path_to_output))
+    pane_1.send_keys("cd ~/oxford-lab/lidar_slam_ws/")
+    pane_1.send_keys("source devel/setup.bash")
+    pane_1.send_keys("roslaunch lio_sam run_hesai.launch arg_savePCDDirectory:={}".format(path_to_output))
     print("SC-LIO-SAM launched!! - run_hesai.launch")
 
     time.sleep(5)
-    
-    pane_2.send_keys('cd {}'.format(path_to_rosbag))
-    pane_2.send_keys('rosbag play *.bag --clock')
+
+    pane_2.send_keys("cd {}".format(path_to_rosbag))
+    pane_2.send_keys("rosbag play *.bag --clock")
     print("Starting rosbag files in {}".format(path_to_rosbag))
 
     # Check if the rosbag is "Done."
-    t  = time.time()
+    t = time.time()
     flag_end = False
-    while (1):
+    while 1:
         pane_2.clear()
         time.sleep(1)
         cap_curr = pane_2.capture_pane()
         for line in cap_curr:
             if "[RUNNING]" in line:
-                t  = time.time()
+                t = time.time()
                 print(line)
                 sys.stdout.write("\033[F")
-            if 'Done.' in line:
-                t  = time.time()
+            if "Done." in line:
+                t = time.time()
                 flag_end = True
                 sys.stdout.write("\033[K")
-                print('Done.') 
+                print("Done.")
                 break
         if flag_end:
             break
-        if (time.time() - t) > 60.0: # To avoid infinite
-            print('Timeout!!')
+        if (time.time() - t) > 60.0:  # To avoid infinite
+            print("Timeout!!")
             break
 
     print("PROCESS FINISHED!!")
@@ -66,14 +65,17 @@ def run_sc_lio_sam (path_to_rosbag, path_to_output):
     server.kill()
 
 
-def convert_to_tum (path_to_output, path_to_sec):
-
+def convert_to_tum(path_to_output, path_to_sec):
     print("Convert from KITTI format to TUM!!")
 
     pose_path = file_interface.read_kitti_poses_file(path_to_output + "optimized_poses.txt")
     raw_timestamps_mat = file_interface.csv_read_matrix(path_to_output + "times.txt")
-    error_msg = ("timestamp file must have one column of timestamps and same number of rows as the KITTI poses file")
-    if len(raw_timestamps_mat) > 0 and len(raw_timestamps_mat[0]) != 1 or len(raw_timestamps_mat) != pose_path.num_poses:
+    error_msg = "timestamp file must have one column of timestamps and same number of rows as the KITTI poses file"
+    if (
+        len(raw_timestamps_mat) > 0
+        and len(raw_timestamps_mat[0]) != 1
+        or len(raw_timestamps_mat) != pose_path.num_poses
+    ):
         raise file_interface.FileInterfaceException(error_msg)
     try:
         timestamps_mat = np.array(raw_timestamps_mat).astype(float)
@@ -88,81 +90,83 @@ def convert_to_tum (path_to_output, path_to_sec):
     print("*********************************************************")
 
 
-def eval_sc_lio_sam (path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir):
-
+def eval_sc_lio_sam(path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir):
     path_traj = path_to_sec + "/output_slam" + "/lio_sam_tum.txt"
-    output = run_command("evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False)
-    
+    output = run_command(
+        "evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False
+    )
+
     rmse = -1
     for line in output.stdout:
         print(line, end="")
         if "rmse" in line:
-            numbers = re.findall('\d+\.\d+|\d+', line)
+            numbers = re.findall("\d+\.\d+|\d+", line)
             rmse = numbers[0]
-    
+
     logging.basicConfig(filename=dataset_dir + "results.log", filemode="a", level=logging.INFO)
     logging.info(path_to_sec)
     logging.info("APE - RMSE result (SC-LIO-SAM): {}".format(rmse))
     print("RMSE added to log: {}".format(rmse))
 
-def create_output_folder (path_to_sec):
+
+def create_output_folder(path_to_sec):
     path_to_output = path_to_sec + "/output_slam" + "/liosam_raw_output/"
     if not os.path.exists(path_to_output):
-            os.makedirs(path_to_output)
+        os.makedirs(path_to_output)
     return path_to_output
 
-def get_sec_list (dataset_dir, flag_is_all=True):
+
+def get_sec_list(dataset_dir, flag_is_all=True):
     if flag_is_all:
         list_sec = os.listdir(dataset_dir)
     else:
         list_sec = [
-                    "2024-03-12-keble-college-02",
-                    "2024-03-12-keble-college-03",
-                    "2024-03-12-keble-college-04",
-                    "2024-03-12-keble-college-05",
-                    "2024-03-13-observatory-quarter-01",
-                    "2024-03-13-observatory-quarter-02",
-                    "2024-03-14-blenheim-palace-01",
-                    "2024-03-14-blenheim-palace-02",
-                    "2024-03-14-blenheim-palace-05",
-                    "2024-03-18-christ-church-01",
-                    "2024-03-18-christ-church-02",
-                    "2024-03-18-christ-church-03",
-                    "2024-03-20-christ-church-05",
-                    "2024-05-20-bodleian-library-02",
-                    "2024-05-20-bodleian-library-03",
-                    "2024-05-20-bodleian-library-04",
-                    "2024-05-20-bodleian-library-05"
-                    ]
+            "2024-03-12-keble-college-02",
+            "2024-03-12-keble-college-03",
+            "2024-03-12-keble-college-04",
+            "2024-03-12-keble-college-05",
+            "2024-03-13-observatory-quarter-01",
+            "2024-03-13-observatory-quarter-02",
+            "2024-03-14-blenheim-palace-01",
+            "2024-03-14-blenheim-palace-02",
+            "2024-03-14-blenheim-palace-05",
+            "2024-03-18-christ-church-01",
+            "2024-03-18-christ-church-02",
+            "2024-03-18-christ-church-03",
+            "2024-03-20-christ-church-05",
+            "2024-05-20-bodleian-library-02",
+            "2024-05-20-bodleian-library-03",
+            "2024-05-20-bodleian-library-04",
+            "2024-05-20-bodleian-library-05",
+        ]
     return list_sec
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     # -------------------------------------------------------------------------------- #
     # TODO: get path from arg an define folders in the future class.
     package_dir = "/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_dataset"
-    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/" 
+    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/"
     flag_is_all = False
     # -------------------------------------------------------------------------------- #
 
-    list_sec = get_sec_list (dataset_dir, flag_is_all)
-    
-    print('Total sequence folders: ' + str(len(list_sec)))
-    
+    list_sec = get_sec_list(dataset_dir, flag_is_all)
+
+    print("Total sequence folders: " + str(len(list_sec)))
+
     # Print list of sequences
     for sec in list_sec:
-
         path_to_sec = dataset_dir + sec
-        path_to_rosbag = "/home/mice85/data/" + sec + "/rosbag/" #path_to_sec + "/rosbag/"
+        path_to_rosbag = "/home/mice85/data/" + sec + "/rosbag/"  # path_to_sec + "/rosbag/"
         path_to_gt = path_to_sec + "/ground_truth_traj/gt_lidar.txt"
-        path_to_output = create_output_folder (path_to_sec)
+        path_to_output = create_output_folder(path_to_sec)
 
-        run_sc_lio_sam (path_to_rosbag, path_to_output)
+        run_sc_lio_sam(path_to_rosbag, path_to_output)
 
         time.sleep(5)
 
-        convert_to_tum (path_to_output, path_to_sec)
+        convert_to_tum(path_to_output, path_to_sec)
 
-        eval_sc_lio_sam (path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir)
+        eval_sc_lio_sam(path_to_gt, path_to_output, package_dir, path_to_sec, dataset_dir)
 
         # break

--- a/scripts/localisation_benchmark/vilens_hba.py
+++ b/scripts/localisation_benchmark/vilens_hba.py
@@ -7,42 +7,44 @@ sys.path.append("/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_da
 from oxford_spires_utils.bash_command import run_command
 
 
-def get_sec_list (dataset_dir, flag_is_all=True):
+def get_sec_list(dataset_dir, flag_is_all=True):
     if flag_is_all:
         list_sec = os.listdir(dataset_dir)
     else:
         list_sec = [
-                    "2024-03-12-keble-college-02",
-                    "2024-03-12-keble-college-03",
-                    "2024-03-12-keble-college-04",
-                    "2024-03-12-keble-college-05",
-                    "2024-03-13-observatory-quarter-01",
-                    "2024-03-13-observatory-quarter-02",
-                    "2024-03-14-blenheim-palace-01",
-                    "2024-03-14-blenheim-palace-02",
-                    "2024-03-14-blenheim-palace-05",
-                    "2024-03-18-christ-church-01",
-                    "2024-03-18-christ-church-02",
-                    "2024-03-18-christ-church-03",
-                    "2024-03-20-christ-church-05",
-                    "2024-05-20-bodleian-library-02",
-                    "2024-05-20-bodleian-library-03",
-                    "2024-05-20-bodleian-library-04",
-                    "2024-05-20-bodleian-library-05"
-                    ]
+            "2024-03-12-keble-college-02",
+            "2024-03-12-keble-college-03",
+            "2024-03-12-keble-college-04",
+            "2024-03-12-keble-college-05",
+            "2024-03-13-observatory-quarter-01",
+            "2024-03-13-observatory-quarter-02",
+            "2024-03-14-blenheim-palace-01",
+            "2024-03-14-blenheim-palace-02",
+            "2024-03-14-blenheim-palace-05",
+            "2024-03-18-christ-church-01",
+            "2024-03-18-christ-church-02",
+            "2024-03-18-christ-church-03",
+            "2024-03-20-christ-church-05",
+            "2024-05-20-bodleian-library-02",
+            "2024-05-20-bodleian-library-03",
+            "2024-05-20-bodleian-library-04",
+            "2024-05-20-bodleian-library-05",
+        ]
     return list_sec
 
-def evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, method):
-    
-    output = run_command("evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False)
-    
+
+def evaluation_ape_rmse(path_to_gt, path_traj, dataset_dir, method):
+    output = run_command(
+        "evo_ape tum {} {} --align --t_max_diff 0.01".format(path_to_gt, path_traj), print_output=False
+    )
+
     rmse = -1
     for line in output.stdout:
         print(line, end="")
         if "rmse" in line:
-            numbers = re.findall('\d+\.\d+|\d+', line)
+            numbers = re.findall("\d+\.\d+|\d+", line)
             rmse = numbers[0]
-    
+
     logging.basicConfig(filename=dataset_dir + "results.log", filemode="a", level=logging.INFO)
     logging.info(path_to_sec)
     logging.info("APE - RMSE result ({}): {}".format(method, rmse))
@@ -50,31 +52,29 @@ def evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, method):
 
     return rmse
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     # -------------------------------------------------------------------------------- #
     # TODO: get path from arg an define folders in the future class.
     package_dir = "/home/mice85/oxford-lab/labrobotica/algorithms/oxford_spires_dataset"
-    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/" 
+    dataset_dir = "/media/mice85/blackdrive1/oxford_spires_dataset/data/"
     flag_is_all = False
     # -------------------------------------------------------------------------------- #
 
-    list_sec = get_sec_list (dataset_dir, flag_is_all)
-    
-    print('Total sequence folders: ' + str(len(list_sec)))
-    
+    list_sec = get_sec_list(dataset_dir, flag_is_all)
+
+    print("Total sequence folders: " + str(len(list_sec)))
+
     # Print list of sequences
     for sec in list_sec:
-        
         path_to_sec = dataset_dir + sec
         path_to_gt = path_to_sec + "/ground_truth_traj/gt_lidar.txt"
 
         print("RUNNING VILENS EVALUATION ...")
         path_traj = path_to_sec + "/output_slam" + "/vilens_poses_tum.txt"
-        rmse = evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, "VILENS")
+        rmse = evaluation_ape_rmse(path_to_gt, path_traj, dataset_dir, "VILENS")
 
         file_name = "hba_poses_tum.txt"
         path_traj = path_to_sec + "/output_slam" + "/hba_poses_tum.txt"
         print("RUNNING HBA EVALUATION ...")
-        rmse = evaluation_ape_rmse (path_to_gt, path_traj, dataset_dir, "HBA")
-    
+        rmse = evaluation_ape_rmse(path_to_gt, path_traj, dataset_dir, "HBA")

--- a/scripts/reconstruction_benchmark/mvs.py
+++ b/scripts/reconstruction_benchmark/mvs.py
@@ -17,7 +17,7 @@ def run_colmap_mvs(image_path, colmap_output_path, sparse_folder, max_image_size
         "colmap image_undistorter",
         f"--image_path {image_path}",
         f"--input_path {sparse_folder}",
-        f"--output_path {colmap_output_path/'dense'}",
+        f"--output_path {colmap_output_path / 'dense'}",
         "--output_type COLMAP",
         f"--max_image_size {max_image_size}",
     ]
@@ -26,7 +26,7 @@ def run_colmap_mvs(image_path, colmap_output_path, sparse_folder, max_image_size
 
     colmap_patch_match_stereo_cmd = [
         "colmap patch_match_stereo",
-        f"--workspace_path {colmap_output_path/'dense'}",
+        f"--workspace_path {colmap_output_path / 'dense'}",
         "--workspace_format COLMAP",
         "--PatchMatchStereo.geom_consistency true",
     ]
@@ -35,18 +35,18 @@ def run_colmap_mvs(image_path, colmap_output_path, sparse_folder, max_image_size
 
     colmap_stereo_fusion_cmd = [
         "colmap stereo_fusion",
-        f"--workspace_path {colmap_output_path/'dense'}",
+        f"--workspace_path {colmap_output_path / 'dense'}",
         "--workspace_format COLMAP",
         "--input_type geometric",
-        f"--output_path {colmap_output_path /'dense'/'fused.ply'}",
+        f"--output_path {colmap_output_path / 'dense' / 'fused.ply'}",
     ]
     colmap_stereo_fusion_cmd = " ".join(colmap_stereo_fusion_cmd)
     run_command(colmap_stereo_fusion_cmd, print_command=True)
 
     colmap_delauany_mesh_filter_cmd = [
         "colmap delaunay_mesher",
-        f"--input_path {colmap_output_path /'dense'}",
-        f"--output_path {colmap_output_path /'dense'/'meshed-delaunay.ply'}",
+        f"--input_path {colmap_output_path / 'dense'}",
+        f"--output_path {colmap_output_path / 'dense' / 'meshed-delaunay.ply'}",
     ]
     colmap_delauany_mesh_filter_cmd = " ".join(colmap_delauany_mesh_filter_cmd)
     run_command(colmap_delauany_mesh_filter_cmd, print_command=True)

--- a/scripts/reconstruction_benchmark/nerf.py
+++ b/scripts/reconstruction_benchmark/nerf.py
@@ -98,7 +98,7 @@ def run_nerfstudio(ns_config, ns_data_config, export_cloud=True):
     cloud = o3d.io.read_point_cloud(str(output_cloud_file))
     cloud.transform(scale_matrix)
     cloud.transform(np.linalg.inv(ns_se3))
-    final_metric_cloud_file = output_cloud_file.with_name(f'{ns_config["method"]}_cloud_metric.pcd')
+    final_metric_cloud_file = output_cloud_file.with_name(f"{ns_config['method']}_cloud_metric.pcd")
     o3d.io.write_point_cloud(str(final_metric_cloud_file), cloud)
     return final_metric_cloud_file
 

--- a/scripts/reconstruction_benchmark/nerf_json.py
+++ b/scripts/reconstruction_benchmark/nerf_json.py
@@ -78,8 +78,8 @@ json_file = colmap_folder / "transforms.json"
 train_image_folder = dataset_folder / "train_val_image" / "train"
 eval_image_folder = dataset_folder / "train_val_image" / "eval"
 
-assert (train_image_folder / "images").exists(), f"{train_image_folder/'images'} does not exist"
-assert (eval_image_folder / "images").exists(), f"{eval_image_folder/'images'} does not exist"
+assert (train_image_folder / "images").exists(), f"{train_image_folder / 'images'} does not exist"
+assert (eval_image_folder / "images").exists(), f"{eval_image_folder / 'images'} does not exist"
 
 train_save_path = Path(json_file).parent / f"{train_name}.json"
 eval_save_path = Path(json_file).parent / f"{eval_name}.json"

--- a/scripts/reconstruction_benchmark/sfm.py
+++ b/scripts/reconstruction_benchmark/sfm.py
@@ -122,7 +122,7 @@ def run_colmap(
         "colmap image_undistorter",
         f"--image_path {image_path}",
         f"--input_path {sparse_0_path}",
-        f"--output_path {output_path/'dense'}",
+        f"--output_path {output_path / 'dense'}",
         "--output_type COLMAP",
         f"--max_image_size {max_image_size}",
     ]

--- a/spires_cpp/example.py
+++ b/spires_cpp/example.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from spires_cpp import (
-    OcTree,
-    convertOctreeToPointCloud,
-    processPCDFolder,
-    removeUnknownPoints,
-)
+from spires_cpp import OcTree, convertOctreeToPointCloud, processPCDFolder, removeUnknownPoints
 
 pcd_folder = "/home/yifu/data/nerf_data_pipeline/2024-03-13-maths_1/raw/individual_clouds_new"
 resolution = 0.1

--- a/spires_cpp/src/spires_cpp/__init__.py
+++ b/spires_cpp/src/spires_cpp/__init__.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
-from ._core import (
-    OcTree,
-    __doc__,
-    __version__,
-    convertOctreeToPointCloud,
-    processPCDFolder,
-    removeUnknownPoints,
-)
+from ._core import OcTree, __doc__, __version__, convertOctreeToPointCloud, processPCDFolder, removeUnknownPoints
 
 __all__ = [
     "OcTree",


### PR DESCRIPTION
- replace [`chartboost/ruff-action`](https://github.com/ChartBoost/ruff-action) (discontinued) with [`astral-sh/ruff-action` ](https://github.com/astral-sh/ruff-action)
    - The old version only ran the `ruff check`, not `ruff format`. The Github action missed some formatting problem therefore.
    - I did not use the default `astral-sh/ruff-action@v3` which just runs `ruff check`. I made it more explicit to run three stages. See d8e337c
- bump ruff from 0.8.1 to 0.11.4
    - in 0.9.0 there is a format change. See this [blog post](https://astral.sh/blog/ruff-v0.9.0).
- load ruff config from `pyroject.toml` in both pre-commit and Github action. This ensures that all ruff we run are consistent. In particular, we set the max line width to 120 in pyproject. 
- add `pre-commit` and `ruff` as the dependencies for the pip installation
