### PR TITLE
Add pytest to Github action

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,0 +1,22 @@
+name: Run Pytest
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'  # Change as needed
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -e .
+
+    - name: Run tests
+      run: pytest

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -e .
+        BUILD_CPP=0 pip install -e .
 
     - name: Run tests
       run: pytest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(
     VERSION ${SKBUILD_PROJECT_VERSION}
     LANGUAGES CXX)
 
+# if BUILD_CPP==0, skip and only install Python. Will not require pcl and octomap
+if(DEFINED ENV{BUILD_CPP} AND "$ENV{BUILD_CPP}" STREQUAL "0")
+message(STATUS "Skipping C++ build because BUILD_CPP=0")
+return()
+endif()
+
 set(PYBIND11_NEWPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ To just install `oxford_spires_utils`, build the docker container:
 docker compose -f .docker/oxspires/docker-compose.yml run --build oxspires_utils
 ```
 
+Installing `oxford_spires_utils` requires PCL and Octomap installation. If you just want to install the python package, run:
+```bash
+BUILD_CPP=0 pip install .
+```
+
 ## Contributing
 Please refer to the [contributing](docs/contributing.md) page.
 


### PR DESCRIPTION
This PR adds pytest to Github actions.

Currently, we only have python-based tests ,i.e., we do not test the cpp packages. To enable easy installation of the python package, we add a flag `BUILD_CPP` to skip the cpp dependency check.

To install without cpp (and pcl, octomap):
```bash
BUILD_CPP=0 pip install .
```

In this mode, if you try to run the cpp package, you will get the following error:
```bash
ModuleNotFoundError: No module named 'oxford_spires_utils.cpp'
```