### PR TITLE
Visualise sensor frames

### DIFF
--- a/oxspires_tools/sensor.py
+++ b/oxspires_tools/sensor.py
@@ -82,7 +82,7 @@ class Sensor:
     def set_sensor_frames(self):
         self.tf = TransformManager()
         self.tf.add_transform("imu", "base", self.T_base_imu)
-        self.tf.add_transform("base", "lidar", self.T_base_lidar)
+        self.tf.add_transform("lidar", "base", self.T_base_lidar)
         for camera in self.cameras:
             self.tf.add_transform("imu", camera.label, camera.T_cam_imu)
 


### PR DESCRIPTION
This PR adds a simple function to save sensor frames of Frontier using `matplotlib`. The sensor frames are managed by [`pytransforms3d`](https://github.com/dfki-ric/pytransform3d).

Also we fixed a bug in parsing the transforms in the sensor class.

## Python script
```python
from oxspires_tools.sensor import Sensor
from pathlib import Path
import yaml

config_yaml_path = Path("/home/yifu/workspace/oxford_spires_dataset/config/sensor.yaml")
with open(config_yaml_path, "r") as f:
    yaml_data = yaml.safe_load(f)
sensor = Sensor(**yaml_data["sensor"])
sensor.viz_sensor_frames()
```

![sensor_frames](https://github.com/user-attachments/assets/a6a1afa6-84d8-47d0-870f-84a06de3b8c5)
## Reference
This is the visualisation in the paper as a reference
<img src="https://github.com/user-attachments/assets/2c2458b7-5778-419d-925e-81c6ee3d7dbf" height="400" />
