### PR TITLE
refactor: add configs to dataset download 

### DIFF
--- a/.docker/oxspires/docker-compose.yml
+++ b/.docker/oxspires/docker-compose.yml
@@ -21,3 +21,4 @@ services:
       - ../../data:${DOCKER_HOME_DIR}/oxford_spires_dataset/data
       - ../../Taskfile.yml:${DOCKER_HOME_DIR}/oxford_spires_dataset/Taskfile.yml
       - ../../outputs:${DOCKER_HOME_DIR}/oxford_spires_dataset/outputs
+      - ../../logs:${DOCKER_HOME_DIR}/oxford_spires_dataset/logs

--- a/.docker/oxspires/docker-compose.yml
+++ b/.docker/oxspires/docker-compose.yml
@@ -21,4 +21,4 @@ services:
       - ../../data:${DOCKER_HOME_DIR}/oxford_spires_dataset/data
       - ../../Taskfile.yml:${DOCKER_HOME_DIR}/oxford_spires_dataset/Taskfile.yml
       - ../../outputs:${DOCKER_HOME_DIR}/oxford_spires_dataset/outputs
-      - ../../logs:${DOCKER_HOME_DIR}/oxford_spires_dataset/logs
+      - ../../runs:${DOCKER_HOME_DIR}/oxford_spires_dataset/runs

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 
 vocab_tree*.bin
 .claude
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,10 @@ cover/
 *.mo
 *.pot
 
+# Runs / logs
+runs/
+
 # Django stuff:
-*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ pip install .
 
 To use the cpp/python binding, you need to install PCL and Octomap. You can either build the docker container:
 ```bash
-docker compose -f .docker/oxspires/docker-compose.yml run --build --rm oxspires_utils bash
+mkdir -p data outputs runs
+DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f .docker/oxspires/docker-compose.yml run --build --rm oxspires_utils bash
 ```
-Or install the dependencies manually and then run
+
+Or install the dependencies manually and then run:
 ```bash
 BUILD_CPP=1 pip install .
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,13 +9,13 @@ tasks:
   docker_build_run:
     desc: Build and run development Docker container -- e.g. task docker_build_run -- task test
     cmds:
-      - mkdir -p data outputs
+      - mkdir -p data outputs runs
       - DOCKER_USERNAME=$(id -un) DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --build --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
 
   docker_run:
     desc: Run a command in Docker without rebuilding -- e.g. task docker_run -- python3 script.py
     cmds:
-      - mkdir -p data outputs
+      - mkdir -p data outputs runs
       - DOCKER_USERNAME=$(id -un) DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
 
   # ── Scripts ──────────────────────────────────────────────────────────────

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,13 +10,13 @@ tasks:
     desc: Build and run development Docker container -- e.g. task docker_build_run -- task test
     cmds:
       - mkdir -p data outputs runs
-      - DOCKER_USERNAME=$(id -un) DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --build --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
+      - DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --build --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
 
   docker_run:
     desc: Run a command in Docker without rebuilding -- e.g. task docker_run -- python3 script.py
     cmds:
       - mkdir -p data outputs runs
-      - DOCKER_USERNAME=$(id -un) DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
+      - DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
 
   # ── Scripts ──────────────────────────────────────────────────────────────
 

--- a/configs/dataset_download.yaml
+++ b/configs/dataset_download.yaml
@@ -1,0 +1,30 @@
+# HuggingFace repository
+repo_id: "ori-drs/oxford_spires_dataset"
+repo_type: "dataset"
+
+# Local directory to download data to
+local_dir: "data"
+
+# Patterns to download (list)
+# Common patterns:
+#   - "sequences/*" - download all sequences
+#   - "sequences/2024-03-12-keble-college-02/*" - specific sequence
+#   - "reconstruction_benchmark/*" - reconstruction benchmark
+#   - "novel_view_synthesis_benchmark/*" - NVS benchmark
+#   - "ground_truth_map/*" - ground truth maps
+#   - "calibration/*" - calibration data
+patterns:
+  - "sequences/2024-03-12-keble-college-02/*"
+  - "sequences/2024-03-12-keble-college-03/*"
+  - "sequences/2024-03-12-keble-college-04/*"
+  - "sequences/2024-03-12-keble-college-05/*"
+  - "sequences/2024-03-13-observatory-quarter-01/*"
+  - "sequences/2024-03-13-observatory-quarter-02/*"
+  - "sequences/2024-03-14-blenheim-palace-01/*"
+  - "sequences/2024-03-14-blenheim-palace-02/*"
+  - "sequences/2024-03-14-blenheim-palace-05/*"
+  - "sequences/2024-03-18-christ-church-01/*"
+  - "sequences/2024-03-18-christ-church-02/*"
+  - "sequences/2024-03-18-christ-church-03/*"
+  - "sequences/2024-03-18-christ-church-05/*"
+  - "sequences/2024-05-20-bodleian-library-02/*"

--- a/configs/dataset_download.yaml
+++ b/configs/dataset_download.yaml
@@ -5,6 +5,7 @@ repo_type: "dataset"
 
 # Local directory to download data to
 local_dir: "data"
+download: true
 unpack: true  # Unpack archives (zip, tar, etc.)
 
 # Patterns to download (list)

--- a/configs/dataset_download.yaml
+++ b/configs/dataset_download.yaml
@@ -2,6 +2,7 @@
 # https://huggingface.co/datasets/ori-drs/oxford_spires_dataset
 repo_id: "ori-drs/oxford_spires_dataset"
 repo_type: "dataset"
+branch: "main"
 
 # Local directory to download data to
 local_dir: "data"

--- a/configs/dataset_download.yaml
+++ b/configs/dataset_download.yaml
@@ -7,6 +7,7 @@ repo_type: "dataset"
 local_dir: "data"
 download: true
 unpack: true  # Unpack archives (zip, tar, etc.)
+check: true # validate data 
 
 # Patterns to download (list)
 # Common patterns:

--- a/configs/dataset_download.yaml
+++ b/configs/dataset_download.yaml
@@ -1,4 +1,5 @@
 # HuggingFace repository
+# https://huggingface.co/datasets/ori-drs/oxford_spires_dataset
 repo_id: "ori-drs/oxford_spires_dataset"
 repo_type: "dataset"
 

--- a/configs/dataset_download.yaml
+++ b/configs/dataset_download.yaml
@@ -5,6 +5,7 @@ repo_type: "dataset"
 
 # Local directory to download data to
 local_dir: "data"
+unpack: true  # Unpack archives (zip, tar, etc.)
 
 # Patterns to download (list)
 # Common patterns:

--- a/oxspires_tools/dataset.py
+++ b/oxspires_tools/dataset.py
@@ -27,21 +27,7 @@ def check_image_lidar_sync(
     lidar_dir: Path,
     tolerance_sec: float = 0.0,
 ) -> bool:
-    """
-    Check if LiDAR timestamps are synchronized with image timestamps.
-
-    LiDAR has lower frequency than images, so we check if each LiDAR timestamp
-    has a corresponding image timestamp (within tolerance).
-
-    Args:
-        image_dir: Directory containing image files (*.jpg)
-        lidar_dir: Directory containing LiDAR point cloud files (*.pcd)
-        tolerance_sec: Maximum allowed time difference in seconds.
-            0.0 means exact match required.
-
-    Returns:
-        True if all LiDAR timestamps have matching image timestamps, False otherwise.
-    """
+    """Check if LiDAR timestamps are synchronized with image timestamps."""
     image_dir = Path(image_dir)
     lidar_dir = Path(lidar_dir)
 

--- a/oxspires_tools/dataset.py
+++ b/oxspires_tools/dataset.py
@@ -94,7 +94,9 @@ def check_image_lidar_sync(
 
     # Report results
     matched_count = len(lidar_timestamps) - len(unmatched)
-    logger.info(f"Matched: {matched_count}/{len(lidar_timestamps)} LiDAR timestamps")
+    logger.info(
+        f"Matched: {matched_count / len(lidar_timestamps) * 100:.2f}% ({matched_count}/{len(lidar_timestamps)}) LiDAR timestamps"
+    )
 
     if unmatched:
         logger.error(f"Unmatched LiDAR timestamps ({len(unmatched)}):")

--- a/oxspires_tools/dataset.py
+++ b/oxspires_tools/dataset.py
@@ -1,8 +1,11 @@
+import logging
 from bisect import bisect_left
 from pathlib import Path
 from typing import List
 
 from oxspires_tools.trajectory.file_interfaces.timestamp import TimeStamp
+
+logger = logging.getLogger(__name__)
 
 
 def parse_lidar_timestamp(filename: str) -> str:
@@ -49,7 +52,7 @@ def check_image_lidar_sync(
         image_timestamps.append(ts)
 
     if not image_timestamps:
-        print(f"No images found in {image_dir}")
+        logger.error(f"No images found in {image_dir}")
         return False
 
     # Parse LiDAR timestamps
@@ -60,10 +63,10 @@ def check_image_lidar_sync(
         lidar_timestamps.append(ts)
 
     if not lidar_timestamps:
-        print(f"No LiDAR point clouds found in {lidar_dir}")
+        logger.error(f"No LiDAR point clouds found in {lidar_dir}")
         return False
 
-    print(f"Found {len(image_timestamps)} images, {len(lidar_timestamps)} LiDAR clouds")
+    logger.info(f"Found {len(image_timestamps)} images, {len(lidar_timestamps)} LiDAR clouds")
 
     # Check synchronization
     unmatched: List[TimeStamp] = []
@@ -91,15 +94,15 @@ def check_image_lidar_sync(
 
     # Report results
     matched_count = len(lidar_timestamps) - len(unmatched)
-    print(f"Matched: {matched_count}/{len(lidar_timestamps)} LiDAR timestamps")
+    logger.info(f"Matched: {matched_count}/{len(lidar_timestamps)} LiDAR timestamps")
 
     if unmatched:
-        print(f"Unmatched LiDAR timestamps ({len(unmatched)}):")
+        logger.error(f"Unmatched LiDAR timestamps ({len(unmatched)}):")
         for ts in unmatched[:10]:  # Show first 10
-            print(f"  {ts.t_string}")
+            logger.error(f"  {ts.t_string}")
         if len(unmatched) > 10:
-            print(f"  ... and {len(unmatched) - 10} more")
+            logger.error(f"  ... and {len(unmatched) - 10} more")
         return False
 
-    print("All LiDAR timestamps are synchronized with images")
+    logger.info("All LiDAR timestamps are synchronized with images")
     return True

--- a/oxspires_tools/dataset.py
+++ b/oxspires_tools/dataset.py
@@ -1,0 +1,105 @@
+from bisect import bisect_left
+from pathlib import Path
+from typing import List
+
+from oxspires_tools.trajectory.file_interfaces.timestamp import TimeStamp
+
+
+def parse_lidar_timestamp(filename: str) -> str:
+    assert filename.startswith("cloud_")
+    # Remove "cloud_" prefix
+    timestamp_str = filename[6:]
+    # Replace last underscore with dot
+    parts = timestamp_str.rsplit("_", 1)
+    assert len(parts) == 2
+    assert parts[0].isdigit()
+    assert parts[1].isdigit()
+    assert len(parts[0]) == 10  # sec should be 10 digits
+    assert len(parts[1]) == 9  # nsec should be 9 digits
+    return f"{parts[0]}.{parts[1]}"
+
+
+def check_image_lidar_sync(
+    image_dir: Path,
+    lidar_dir: Path,
+    tolerance_sec: float = 0.0,
+) -> bool:
+    """
+    Check if LiDAR timestamps are synchronized with image timestamps.
+
+    LiDAR has lower frequency than images, so we check if each LiDAR timestamp
+    has a corresponding image timestamp (within tolerance).
+
+    Args:
+        image_dir: Directory containing image files (*.jpg)
+        lidar_dir: Directory containing LiDAR point cloud files (*.pcd)
+        tolerance_sec: Maximum allowed time difference in seconds.
+            0.0 means exact match required.
+
+    Returns:
+        True if all LiDAR timestamps have matching image timestamps, False otherwise.
+    """
+    image_dir = Path(image_dir)
+    lidar_dir = Path(lidar_dir)
+
+    # Parse image timestamps
+    image_timestamps: List[TimeStamp] = []
+    for img_path in sorted(image_dir.glob("*.jpg")):
+        ts = TimeStamp(t_string=img_path.stem)
+        image_timestamps.append(ts)
+
+    if not image_timestamps:
+        print(f"No images found in {image_dir}")
+        return False
+
+    # Parse LiDAR timestamps
+    lidar_timestamps: List[TimeStamp] = []
+    for pcd_path in sorted(lidar_dir.glob("*.pcd")):
+        timestamp_str = parse_lidar_timestamp(pcd_path.stem)
+        ts = TimeStamp(t_string=timestamp_str)
+        lidar_timestamps.append(ts)
+
+    if not lidar_timestamps:
+        print(f"No LiDAR point clouds found in {lidar_dir}")
+        return False
+
+    print(f"Found {len(image_timestamps)} images, {len(lidar_timestamps)} LiDAR clouds")
+
+    # Check synchronization
+    unmatched: List[TimeStamp] = []
+    if tolerance_sec == 0.0:
+        # Exact match: use string comparison
+        image_ts_set = {ts.t_string for ts in image_timestamps}
+        for lidar_ts in lidar_timestamps:
+            if lidar_ts.t_string not in image_ts_set:
+                unmatched.append(lidar_ts)
+    else:
+        # Tolerance-based match: use float comparison with binary search
+        image_floats = [ts.t_float128 for ts in image_timestamps]
+        for lidar_ts in lidar_timestamps:
+            lidar_float = lidar_ts.t_float128
+            # Find closest image timestamp
+            idx = bisect_left(image_floats, lidar_float)
+            # Check both neighbors
+            min_diff = float("inf")
+            for i in [idx - 1, idx]:
+                if 0 <= i < len(image_floats):
+                    diff = abs(float(image_floats[i] - lidar_float))
+                    min_diff = min(min_diff, diff)
+            if min_diff > tolerance_sec:
+                unmatched.append(lidar_ts)
+
+    # Report results
+    matched_count = len(lidar_timestamps) - len(unmatched)
+    print(f"Matched: {matched_count}/{len(lidar_timestamps)} LiDAR timestamps")
+
+    if unmatched:
+        print(f"Unmatched LiDAR timestamps ({len(unmatched)}):")
+        for ts in unmatched[:10]:  # Show first 10
+            print(f"  {ts.t_string}")
+        if len(unmatched) > 10:
+            print(f"  ... and {len(unmatched) - 10} more")
+        return False
+
+    print("All LiDAR timestamps are synchronized with images")
+    return True

--- a/oxspires_tools/utils.py
+++ b/oxspires_tools/utils.py
@@ -18,7 +18,7 @@ from oxspires_tools.trajectory.pose_convention import PoseConvention
 
 
 def setup_logging(logging_dir: Path = None) -> Path:
-    """Set up logging to file and console, returns the logging directory."""
+    """Set up logging to file and console."""
     time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     if logging_dir is None:
         logging_dir = Path(__file__).parent.parent / "runs" / time
@@ -151,9 +151,7 @@ def get_accumulated_pcd(current_pcd, transforms, accumulation_length=0, max_time
 
 
 def find_closest_in_sorted(array: List, value: float):
-    """
-    Find and return closest value and difference
-    """
+    """Find and return closest value and difference."""
     # Over or under any value in the array
     assert isinstance(value, (float, np.float128))
     if array[-1] < value:
@@ -174,20 +172,7 @@ def find_closest_in_sorted(array: List, value: float):
 def get_image_pcd_sync_pair(
     image_dir: Path, pcd_dir: Path, image_ext: str, timestamp_threshold: float = 0.05
 ) -> List[Tuple[Path, Path, float]]:
-    """
-    Find image and point cloud pairs that are synchronized based on their timestamps.
-
-    Args:
-        image_dir (Path): Directory containing the image files.
-        pcd_dir (Path): Directory containing the point cloud files.
-        image_ext (str): File extension of the image files (e.g. ".jpg").
-        timestamp_threshold (float): Maximum time difference allowed between an image and a point cloud, in seconds.
-            Defaults to 0.05.
-
-    Returns:
-        List[Tuple[Path, Path, float]]: A list of tuples, where each tuple represents an image and a point cloud that are
-            synchronized, along with their time difference in seconds.
-    """
+    """Find synchronized image and point cloud pairs based on timestamps."""
     # Load images and timestamps
     image_timestamps = []
     image_paths = {}

--- a/oxspires_tools/utils.py
+++ b/oxspires_tools/utils.py
@@ -1,6 +1,8 @@
+import logging
 import re
 import zipfile
 from bisect import bisect_left
+from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple
 
@@ -13,6 +15,20 @@ from oxspires_tools.point_cloud import convert_e57_to_pcd, transform_3d_cloud
 from oxspires_tools.se3 import se3_matrix_to_xyz_quat_wxyz, xyz_quat_wxyz_to_se3_matrix
 from oxspires_tools.trajectory.file_interfaces import NeRFTrajReader, VilensSlamTrajReader
 from oxspires_tools.trajectory.pose_convention import PoseConvention
+
+
+def setup_logging():
+    time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    Path("logs").mkdir(exist_ok=True)
+    logging.basicConfig(
+        filename=f"logs/recon_benchmark_{time}.log",  # Log file
+        level=logging.DEBUG,  # Set the logging level
+        format="%(asctime)s %(levelname)s %(name)s %(lineno)s: %(message)s",  # Log format
+    )
+    console_handler = logging.StreamHandler()  # Create a console handler
+    console_handler.setLevel(logging.INFO)  # Set the logging level
+    root_logger = logging.getLogger()  # Get the root logger
+    root_logger.addHandler(console_handler)  # Add the console handler to the logger
 
 
 def convert_e57_folder_to_pcd_folder(e57_folder, pcd_folder):

--- a/oxspires_tools/utils.py
+++ b/oxspires_tools/utils.py
@@ -17,13 +17,15 @@ from oxspires_tools.trajectory.file_interfaces import NeRFTrajReader, VilensSlam
 from oxspires_tools.trajectory.pose_convention import PoseConvention
 
 
-def setup_logging():
+def setup_logging(logging_dir: Path = None) -> Path:
+    """Set up logging to file and console, returns the logging directory."""
     time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    project_root = Path(__file__).parent.parent
-    logs_dir = project_root / "logs"
-    logs_dir.mkdir(exist_ok=True)
+    if logging_dir is None:
+        logging_dir = Path(__file__).parent.parent / "runs" / time
+    logging_dir = Path(logging_dir)
+    logging_dir.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
-        filename=logs_dir / f"{time}.log",
+        filename=logging_dir / f"{time}.log",
         level=logging.DEBUG,
         format="%(asctime)s %(levelname)s %(name)s %(lineno)s: %(message)s",
     )
@@ -31,6 +33,7 @@ def setup_logging():
     console_handler.setLevel(logging.INFO)
     root_logger = logging.getLogger()
     root_logger.addHandler(console_handler)
+    return logging_dir
 
 
 def convert_e57_folder_to_pcd_folder(e57_folder, pcd_folder):

--- a/oxspires_tools/utils.py
+++ b/oxspires_tools/utils.py
@@ -19,16 +19,18 @@ from oxspires_tools.trajectory.pose_convention import PoseConvention
 
 def setup_logging():
     time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    Path("logs").mkdir(exist_ok=True)
+    project_root = Path(__file__).parent.parent
+    logs_dir = project_root / "logs"
+    logs_dir.mkdir(exist_ok=True)
     logging.basicConfig(
-        filename=f"logs/recon_benchmark_{time}.log",  # Log file
-        level=logging.DEBUG,  # Set the logging level
-        format="%(asctime)s %(levelname)s %(name)s %(lineno)s: %(message)s",  # Log format
+        filename=logs_dir / f"{time}.log",
+        level=logging.DEBUG,
+        format="%(asctime)s %(levelname)s %(name)s %(lineno)s: %(message)s",
     )
-    console_handler = logging.StreamHandler()  # Create a console handler
-    console_handler.setLevel(logging.INFO)  # Set the logging level
-    root_logger = logging.getLogger()  # Get the root logger
-    root_logger.addHandler(console_handler)  # Add the console handler to the logger
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(console_handler)
 
 
 def convert_e57_folder_to_pcd_folder(e57_folder, pcd_folder):

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -23,6 +23,7 @@ def download_patterns(
     patterns: list,
     local_dir: str,
     repo_type: str = "dataset",
+    branch: str = "main",
     unpack: bool = False,
 ) -> list:
     """Download patterns from the HuggingFace repository."""
@@ -39,6 +40,7 @@ def download_patterns(
             local_dir=local_dir,
             repo_type=repo_type,
             use_auth_token=False,
+            revision=branch,
         )
         logger.info(f"✅ Downloaded: {pattern}\n")
     logger.info("🏁 All downloads complete!")
@@ -78,6 +80,7 @@ def main():
             patterns=config["patterns"],
             local_dir=config["local_dir"],
             repo_type=config["repo_type"],
+            branch=config["branch"],
         )
     if config.get("unpack", True):
         unpack_zip_files(config["local_dir"])

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import yaml
 from huggingface_hub import snapshot_download
 
+from oxspires_tools.dataset import check_image_lidar_sync
+
 
 def load_config(config_path: str) -> dict:
     """Load configuration from YAML file."""
@@ -35,7 +37,6 @@ def download_patterns(
             use_auth_token=False,
         )
         print(f"✅ Downloaded: {pattern}\n")
-
     print("🏁 All downloads complete!")
 
 
@@ -74,6 +75,17 @@ def main():
         )
     if config.get("unpack", True):
         unpack_zip_files(config["local_dir"])
+    if config.get("check", True):
+        sequences = Path(config["local_dir"]) / "sequences"
+        for seq_dir in sequences.iterdir():
+            if not seq_dir.is_dir():
+                continue
+            print(f"\nChecking sequence: {seq_dir.name}")
+            check_image_lidar_sync(
+                image_dir=Path(seq_dir) / "raw" / "cam0",
+                lidar_dir=Path(seq_dir) / "processed" / "vilens-slam" / "undist-clouds",
+                tolerance_sec=0.0,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -68,7 +68,7 @@ def get_args():
 
 
 def main():
-    setup_logging()
+    _ = setup_logging()
     args = get_args()
 
     config = load_config(args.config)

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -1,52 +1,78 @@
+import argparse
+from pathlib import Path
+
+import yaml
 from huggingface_hub import snapshot_download
 
-hf_repo_id = "ori-drs/oxford_spires_dataset"
 
-############## 1. Download a specific sequence or benchmark ##############
-
-# example_pattern = "sequences/*" # download all sequences
-example_pattern = "sequences/2024-03-12-keble-college-02/*"  # download all files in a particular sequence
-# example_pattern = "reconstruction_benchmark/* # download the whole reconstruction benchmark
-# example_pattern = "novel_view_synthesis_benchmark" # download the whole novel view synthesis benchmark
-# example_pattern = "ground_truth_map/*" # download all ground truth maps
+def load_config(config_path: str) -> dict:
+    """Load configuration from YAML file."""
+    with open(config_path, "r") as f:
+        return yaml.safe_load(f)
 
 
-local_dir = "data"
+def download_patterns(repo_id: str, patterns: list, local_dir: str, repo_type: str = "dataset") -> None:
+    """Download patterns from the HuggingFace repository."""
+    print(f"Repository: {repo_id}")
+    print(f"Local directory: {local_dir}")
+    print(f"Downloading {len(patterns)} pattern(s)...\n")
 
-snapshot_download(
-    repo_id=hf_repo_id,
-    allow_patterns=example_pattern,
-    local_dir=local_dir,
-    repo_type="dataset",
-    use_auth_token=False,
-)
+    for i, pattern in enumerate(patterns, 1):
+        print(f"[{i}/{len(patterns)}] {pattern}")
+        snapshot_download(
+            repo_id=repo_id,
+            allow_patterns=pattern,
+            local_dir=local_dir,
+            repo_type=repo_type,
+            use_auth_token=False,
+        )
+        print(f"✅ Downloaded: {pattern}\n")
 
-############## 2. Download the core sequences ##############
-core_sequences = [
-    "sequences/2024-03-12-keble-college-02/*",
-    "sequences/2024-03-12-keble-college-03/*",
-    "sequences/2024-03-12-keble-college-04/*",
-    "sequences/2024-03-12-keble-college-05/*",
-    "sequences/2024-03-13-observatory-quarter-01/*",
-    "sequences/2024-03-13-observatory-quarter-02/*",
-    "sequences/2024-03-14-blenheim-palace-01/*",
-    "sequences/2024-03-14-blenheim-palace-02/*",
-    "sequences/2024-03-14-blenheim-palace-05/*",
-    "sequences/2024-03-18-christ-church-01/*",
-    "sequences/2024-03-18-christ-church-02/*",
-    "sequences/2024-03-18-christ-church-03/*",
-    "sequences/2024-03-18-christ-church-05/*",
-    "sequences/2024-05-20-bodleian-library-02/*",
-]
+    print("🏁 All downloads complete!")
 
 
-for sequence in core_sequences:
-    example_pattern = sequence
-    print(f"Downloading sequence: {example_pattern}")
-    snapshot_download(
-        repo_id=hf_repo_id,
-        allow_patterns=example_pattern,
-        local_dir=local_dir,
-        repo_type="dataset",
-        use_auth_token=False,
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="configs/dataset_download.yaml",
+        help="Path to configuration file (default: config/dataset_download.yaml)",
     )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        nargs="+",
+        help="Pattern(s) to download (overrides config patterns)",
+    )
+    parser.add_argument(
+        "--local-dir",
+        type=str,
+        help="Local directory to download to (overrides config)",
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        help="HuggingFace repository ID (overrides config)",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = get_args()
+
+    config = load_config(args.config)
+
+    repo_id = args.repo_id or config["repo_id"]
+    local_dir = args.local_dir or config["local_dir"]
+    repo_type = config["repo_type"]
+    patterns = args.pattern or config["patterns"]
+
+    Path(local_dir).mkdir(parents=True, exist_ok=True)
+
+    download_patterns(repo_id, patterns, local_dir, repo_type)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -55,22 +55,6 @@ def get_args():
         default="configs/dataset_download.yaml",
         help="Path to configuration file (default: config/dataset_download.yaml)",
     )
-    parser.add_argument(
-        "--pattern",
-        type=str,
-        nargs="+",
-        help="Pattern(s) to download (overrides config patterns)",
-    )
-    parser.add_argument(
-        "--local-dir",
-        type=str,
-        help="Local directory to download to (overrides config)",
-    )
-    parser.add_argument(
-        "--repo-id",
-        type=str,
-        help="HuggingFace repository ID (overrides config)",
-    )
     args = parser.parse_args()
     return args
 
@@ -79,17 +63,17 @@ def main():
     args = get_args()
 
     config = load_config(args.config)
+    Path(config["local_dir"]).mkdir(parents=True, exist_ok=True)
 
-    repo_id = args.repo_id or config["repo_id"]
-    local_dir = args.local_dir or config["local_dir"]
-    repo_type = config["repo_type"]
-    patterns = args.pattern or config["patterns"]
-
-    Path(local_dir).mkdir(parents=True, exist_ok=True)
-
-    download_patterns(repo_id, patterns, local_dir, repo_type)
+    if config.get("download", True):
+        download_patterns(
+            repo_id=config["repo_id"],
+            patterns=config["patterns"],
+            local_dir=config["local_dir"],
+            repo_type=config["repo_type"],
+        )
     if config.get("unpack", True):
-        unpack_zip_files(local_dir)
+        unpack_zip_files(config["local_dir"])
 
 
 if __name__ == "__main__":

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -1,4 +1,5 @@
 import argparse
+import shutil
 from pathlib import Path
 
 import yaml
@@ -11,10 +12,17 @@ def load_config(config_path: str) -> dict:
         return yaml.safe_load(f)
 
 
-def download_patterns(repo_id: str, patterns: list, local_dir: str, repo_type: str = "dataset") -> None:
+def download_patterns(
+    repo_id: str,
+    patterns: list,
+    local_dir: str,
+    repo_type: str = "dataset",
+    unpack: bool = False,
+) -> list:
     """Download patterns from the HuggingFace repository."""
     print(f"Repository: {repo_id}")
     print(f"Local directory: {local_dir}")
+    print(f"Unpack archives: {unpack}")
     print(f"Downloading {len(patterns)} pattern(s)...\n")
 
     for i, pattern in enumerate(patterns, 1):
@@ -29,6 +37,14 @@ def download_patterns(repo_id: str, patterns: list, local_dir: str, repo_type: s
         print(f"✅ Downloaded: {pattern}\n")
 
     print("🏁 All downloads complete!")
+
+
+def unpack_zip_files(local_dir: str):
+    zip_files = list(Path(local_dir).rglob("*.zip"))
+    for zip_file in zip_files:
+        print(f"Unzipping {zip_file}")
+        shutil.unpack_archive(zip_file, extract_dir=zip_file.parent)
+        zip_file.unlink()
 
 
 def get_args():
@@ -72,6 +88,8 @@ def main():
     Path(local_dir).mkdir(parents=True, exist_ok=True)
 
     download_patterns(repo_id, patterns, local_dir, repo_type)
+    if config.get("unpack", True):
+        unpack_zip_files(local_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -32,7 +32,7 @@ def download_patterns(
     logger.info(f"Downloading {len(patterns)} pattern(s)...\n")
 
     for i, pattern in enumerate(patterns, 1):
-        logger.info(f"[{i}/{len(patterns)}] {pattern}")
+        logger.info(f"🚀 [{i}/{len(patterns)}] {pattern}")
         snapshot_download(
             repo_id=repo_id,
             allow_patterns=pattern,
@@ -50,6 +50,7 @@ def unpack_zip_files(local_dir: str):
         logger.info(f"Unzipping {zip_file}")
         shutil.unpack_archive(zip_file, extract_dir=zip_file.parent)
         zip_file.unlink()
+    logger.info("🏁 All zip files unpacked!")
 
 
 def get_args():
@@ -81,14 +82,16 @@ def main():
     if config.get("unpack", True):
         unpack_zip_files(config["local_dir"])
     if config.get("check", True):
-        sequences = Path(config["local_dir"]) / "sequences"
-        for seq_dir in sequences.iterdir():
+        sequences_dir = Path(config["local_dir"]) / "sequences"
+        sequences_list = sorted([d.name for d in sequences_dir.iterdir() if d.is_dir()])
+        for i, seq_name in enumerate(sequences_list):
+            seq_dir = sequences_dir / seq_name
             if not seq_dir.is_dir():
                 continue
-            logger.info(f"\nChecking sequence: {seq_dir.name}")
+            logger.info(f"\n🚀 [{i}/{len(sequences_list)}] Checking sequence: {seq_dir.name}")
             check_image_lidar_sync(
-                image_dir=Path(seq_dir) / "raw" / "cam0",
-                lidar_dir=Path(seq_dir) / "processed" / "vilens-slam" / "undist-clouds",
+                image_dir=seq_dir / "raw" / "cam0",
+                lidar_dir=seq_dir / "processed" / "vilens-slam" / "undist-clouds",
                 tolerance_sec=0.0,
             )
 

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import shutil
 from pathlib import Path
 
@@ -6,6 +7,9 @@ import yaml
 from huggingface_hub import snapshot_download
 
 from oxspires_tools.dataset import check_image_lidar_sync
+from oxspires_tools.utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def load_config(config_path: str) -> dict:
@@ -22,13 +26,13 @@ def download_patterns(
     unpack: bool = False,
 ) -> list:
     """Download patterns from the HuggingFace repository."""
-    print(f"Repository: {repo_id}")
-    print(f"Local directory: {local_dir}")
-    print(f"Unpack archives: {unpack}")
-    print(f"Downloading {len(patterns)} pattern(s)...\n")
+    logger.info(f"Repository: {repo_id}")
+    logger.info(f"Local directory: {local_dir}")
+    logger.info(f"Unpack archives: {unpack}")
+    logger.info(f"Downloading {len(patterns)} pattern(s)...\n")
 
     for i, pattern in enumerate(patterns, 1):
-        print(f"[{i}/{len(patterns)}] {pattern}")
+        logger.info(f"[{i}/{len(patterns)}] {pattern}")
         snapshot_download(
             repo_id=repo_id,
             allow_patterns=pattern,
@@ -36,14 +40,14 @@ def download_patterns(
             repo_type=repo_type,
             use_auth_token=False,
         )
-        print(f"✅ Downloaded: {pattern}\n")
-    print("🏁 All downloads complete!")
+        logger.info(f"✅ Downloaded: {pattern}\n")
+    logger.info("🏁 All downloads complete!")
 
 
 def unpack_zip_files(local_dir: str):
     zip_files = list(Path(local_dir).rglob("*.zip"))
     for zip_file in zip_files:
-        print(f"Unzipping {zip_file}")
+        logger.info(f"Unzipping {zip_file}")
         shutil.unpack_archive(zip_file, extract_dir=zip_file.parent)
         zip_file.unlink()
 
@@ -61,6 +65,7 @@ def get_args():
 
 
 def main():
+    setup_logging()
     args = get_args()
 
     config = load_config(args.config)
@@ -80,7 +85,7 @@ def main():
         for seq_dir in sequences.iterdir():
             if not seq_dir.is_dir():
                 continue
-            print(f"\nChecking sequence: {seq_dir.name}")
+            logger.info(f"\nChecking sequence: {seq_dir.name}")
             check_image_lidar_sync(
                 image_dir=Path(seq_dir) / "raw" / "cam0",
                 lidar_dir=Path(seq_dir) / "processed" / "vilens-slam" / "undist-clouds",

--- a/scripts/reconstruction_benchmark/main.py
+++ b/scripts/reconstruction_benchmark/main.py
@@ -3,7 +3,6 @@ import csv
 import logging
 import shutil
 from copy import deepcopy
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -22,23 +21,9 @@ from oxspires_tools.sensor import Sensor
 from oxspires_tools.trajectory.align import align
 from oxspires_tools.trajectory.file_interfaces import NeRFTrajReader, VilensSlamTrajReader
 from oxspires_tools.trajectory.utils import pose_to_ply
-from oxspires_tools.utils import convert_e57_folder_to_pcd_folder, transform_pcd_folder
+from oxspires_tools.utils import convert_e57_folder_to_pcd_folder, setup_logging, transform_pcd_folder
 
 logger = logging.getLogger(__name__)
-
-
-def setup_logging():
-    time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    Path("logs").mkdir(exist_ok=True)
-    logging.basicConfig(
-        filename=f"logs/recon_benchmark_{time}.log",  # Log file
-        level=logging.DEBUG,  # Set the logging level
-        format="%(asctime)s %(levelname)s %(name)s %(lineno)s: %(message)s",  # Log format
-    )
-    console_handler = logging.StreamHandler()  # Create a console handler
-    console_handler.setLevel(logging.INFO)  # Set the logging level
-    root_logger = logging.getLogger()  # Get the root logger
-    root_logger.addHandler(console_handler)  # Add the console handler to the logger
 
 
 class ReconstructionBenchmark:

--- a/scripts/reconstruction_benchmark/main.py
+++ b/scripts/reconstruction_benchmark/main.py
@@ -248,7 +248,7 @@ def get_args():
 
 
 if __name__ == "__main__":
-    setup_logging()
+    _ = setup_logging()
     recon_config_file = get_args().config_file
     logger.info("Starting Reconstruction Benchmark")
     with open(recon_config_file, "r") as f:


### PR DESCRIPTION
  - Refactors `dataset_download.py` to be config-driven (patterns, repo ID, local dir all in `configs/dataset_download.yaml`) with optional download, unpack, and sync-check steps
  - Moves `setup_logging()` to the `oxspires_tools` package; logs now saved to `runs/<timestamp>/` under the project folder, making it easy to correlate logs with run outputs                                                                                                              
  - Adds HuggingFace branch support to the download config
  - Simplifies all multi-line docstrings to one-liners across the codebase                                                                     
  - Updates Docker compose volume mounts (`logs/` → `runs/`) and README docker commands                                                           