### PR TITLE
refactor: restructure depth generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ cython_debug/
 vocab_tree*.bin
 .claude
 data/
+outputs/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ vars:
   DOCKER_COMPOSE_PATH: .docker/oxspires/docker-compose.yml
 
 tasks:
-  # ── Docker ────────────────────────────────────────────────────────────────
+  ##### Docker ####################################
 
   docker_build_run:
     desc: Build and run development Docker container -- e.g. task docker_build_run -- task test
@@ -18,14 +18,24 @@ tasks:
       - mkdir -p data outputs runs
       - DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f {{.DOCKER_COMPOSE_PATH}} run --rm oxspires_utils bash -c "source ~/.bashrc && {{.CLI_ARGS | default "bash"}}"
 
-  # ── Scripts ──────────────────────────────────────────────────────────────
+  ##### Scripts ####################################
 
   download:
     desc: Download dataset using patterns from config -- e.g. task download -- --patterns sequences/foo1/* sequences/foo2/*
     cmds:
       - "python scripts/dataset_download.py {{.CLI_ARGS}}"
 
-  # ── Dev ───────────────────────────────────────────────────────────────────
+  generate_depth:
+    desc: Download required data and generate depth maps -- e.g. task generate_depth SEQUENCE=2024-03-18-christ-church-01
+    vars:
+      SEQUENCE: '{{.SEQUENCE | default "2024-03-18-christ-church-01"}}'
+    cmds:
+      - task: download
+        vars:
+          CLI_ARGS: "--patterns sequences/{{.SEQUENCE}}/processed/vilens-slam/undist-clouds.zip sequences/{{.SEQUENCE}}/processed/colmap/images.zip"
+      - "python scripts/generate_depth.py --sequence {{.SEQUENCE}}"
+
+  ##### Dev ####################################
 
   install:
     desc: Install the package in development mode

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,14 +26,9 @@ tasks:
       - "python scripts/dataset_download.py {{.CLI_ARGS}}"
 
   generate_depth:
-    desc: Download required data and generate depth maps -- e.g. task generate_depth SEQUENCE=2024-03-18-christ-church-01
-    vars:
-      SEQUENCE: '{{.SEQUENCE | default "2024-03-18-christ-church-01"}}'
+    desc: Generate depth maps -- e.g. task generate_depth -- --sequence_dir data/sequences/2024-03-18-christ-church-01
     cmds:
-      - task: download
-        vars:
-          CLI_ARGS: "--patterns sequences/{{.SEQUENCE}}/processed/vilens-slam/undist-clouds.zip sequences/{{.SEQUENCE}}/processed/colmap/images.zip"
-      - "python scripts/generate_depth.py --sequence {{.SEQUENCE}}"
+      - "python scripts/generate_depth.py {{.CLI_ARGS}}"
 
   ##### Dev ####################################
 

--- a/oxspires_tools/dataset.py
+++ b/oxspires_tools/dataset.py
@@ -1,96 +1,161 @@
 import logging
-from bisect import bisect_left
 from pathlib import Path
 from typing import List
 
 from oxspires_tools.trajectory.file_interfaces.timestamp import TimeStamp
+from oxspires_tools.utils import find_closest_in_sorted
 
 logger = logging.getLogger(__name__)
 
 
-def parse_lidar_timestamp(filename: str) -> str:
-    assert filename.startswith("cloud_")
-    # Remove "cloud_" prefix
-    timestamp_str = filename[6:]
-    # Replace last underscore with dot
-    parts = timestamp_str.rsplit("_", 1)
-    assert len(parts) == 2
-    assert parts[0].isdigit()
-    assert parts[1].isdigit()
-    assert len(parts[0]) == 10  # sec should be 10 digits
-    assert len(parts[1]) == 9  # nsec should be 9 digits
-    return f"{parts[0]}.{parts[1]}"
+class OxfordSpiresDataset:
+    """Centralised path management and common checks for a SPIRES sequence."""
 
-
-def check_image_lidar_sync(
-    image_dir: Path,
-    lidar_dir: Path,
-    tolerance_sec: float = 0.0,
-) -> bool:
-    """Check if LiDAR timestamps are synchronized with image timestamps."""
-    image_dir = Path(image_dir)
-    lidar_dir = Path(lidar_dir)
-
-    # Parse image timestamps
-    image_timestamps: List[TimeStamp] = []
-    for img_path in sorted(image_dir.glob("*.jpg")):
-        ts = TimeStamp(t_string=img_path.stem)
-        image_timestamps.append(ts)
-
-    if not image_timestamps:
-        logger.error(f"No images found in {image_dir}")
-        return False
-
-    # Parse LiDAR timestamps
-    lidar_timestamps: List[TimeStamp] = []
-    for pcd_path in sorted(lidar_dir.glob("*.pcd")):
-        timestamp_str = parse_lidar_timestamp(pcd_path.stem)
-        ts = TimeStamp(t_string=timestamp_str)
-        lidar_timestamps.append(ts)
-
-    if not lidar_timestamps:
-        logger.error(f"No LiDAR point clouds found in {lidar_dir}")
-        return False
-
-    logger.info(f"Found {len(image_timestamps)} images, {len(lidar_timestamps)} LiDAR clouds")
-
-    # Check synchronization
-    unmatched: List[TimeStamp] = []
-    if tolerance_sec == 0.0:
-        # Exact match: use string comparison
-        image_ts_set = {ts.t_string for ts in image_timestamps}
-        for lidar_ts in lidar_timestamps:
-            if lidar_ts.t_string not in image_ts_set:
-                unmatched.append(lidar_ts)
-    else:
-        # Tolerance-based match: use float comparison with binary search
-        image_floats = [ts.t_float128 for ts in image_timestamps]
-        for lidar_ts in lidar_timestamps:
-            lidar_float = lidar_ts.t_float128
-            # Find closest image timestamp
-            idx = bisect_left(image_floats, lidar_float)
-            # Check both neighbors
-            min_diff = float("inf")
-            for i in [idx - 1, idx]:
-                if 0 <= i < len(image_floats):
-                    diff = abs(float(image_floats[i] - lidar_float))
-                    min_diff = min(min_diff, diff)
-            if min_diff > tolerance_sec:
-                unmatched.append(lidar_ts)
-
-    # Report results
-    matched_count = len(lidar_timestamps) - len(unmatched)
-    logger.info(
-        f"Matched: {matched_count / len(lidar_timestamps) * 100:.2f}% ({matched_count}/{len(lidar_timestamps)}) LiDAR timestamps"
+    RAW_CAM_IDS = (0, 1, 2)
+    TRAJECTORY_FILES = ("gt-tum.txt", "vilens-slam-tum.txt", "hba-tum.txt", "colmap-tum.txt")
+    PATH_MAP = {
+        "raw_cam0": "raw/cam0",
+        "raw_cam1": "raw/cam1",
+        "raw_cam2": "raw/cam2",
+        "raw_imu": "raw/imu.csv",
+        "raw_lidar": "raw/lidar-clouds",
+        "raw_ros2bag": "raw/ros2bag",
+        "raw_rosbag": "raw/rosbag",
+        "trajectory_dir": "processed/trajectory",
+        "gt_tum": "processed/trajectory/gt-tum.txt",
+        "slam_poses": "processed/vilens-slam/slam-poses.csv",
+        "vilens_undist_clouds": "processed/vilens-slam/undist-clouds",
+        "colmap_dir": "processed/colmap",
+    }
+    BAG_TOPIC_TO_RAW = {
+        "/alphasense_driver_ros/cam0/debayered/image/compressed": "raw/cam0",
+        "/alphasense_driver_ros/cam1/debayered/image/compressed": "raw/cam1",
+        "/alphasense_driver_ros/cam2/debayered/image/compressed": "raw/cam2",
+        "/alphasense_driver_ros/imu": "raw/imu.csv",
+        "/hesai/pandar": "raw/lidar-clouds",
+    }
+    COLMAP_SPARSE_FILES = ("cameras.bin", "images.bin", "points3D.bin")
+    COLMAP_JSON_FILES = ("transforms_colmap.json", "transforms_colmap_scaled.json", "evo_align_results.json")
+    COLMAP_CAM_DIRS = (
+        "alphasense_driver_ros_cam0_debayered_image_compressed",
+        "alphasense_driver_ros_cam1_debayered_image_compressed",
+        "alphasense_driver_ros_cam2_debayered_image_compressed",
     )
 
-    if unmatched:
-        logger.error(f"Unmatched LiDAR timestamps ({len(unmatched)}):")
-        for ts in unmatched[:10]:  # Show first 10
-            logger.error(f"  {ts.t_string}")
-        if len(unmatched) > 10:
-            logger.error(f"  ... and {len(unmatched) - 10} more")
-        return False
+    def __init__(self, seq_dir: Path):
+        self.seq_dir = seq_dir
 
-    logger.info("All LiDAR timestamps are synchronized with images")
-    return True
+    def get_filepath(self, key: str) -> Path:
+        return Path(self.seq_dir) / self.PATH_MAP[key]
+
+    def get_all_filepaths(self) -> dict[str, Path]:
+        return {key: self.get_filepath(key) for key in self.PATH_MAP}
+
+    def expected_integrity_paths(self) -> list[Path]:
+        """Paths that should exist for a complete sequence integrity check."""
+        return (
+            [self.get_filepath(f"raw_cam{cam_id}") for cam_id in self.RAW_CAM_IDS]
+            + [
+                self.get_filepath("raw_imu"),
+                self.get_filepath("vilens_undist_clouds"),
+                self.get_filepath("slam_poses"),
+            ]
+            + [self.get_filepath("trajectory_dir") / name for name in self.TRAJECTORY_FILES]
+            + [self.get_filepath("colmap_dir") / "database.db"]
+            + [self.get_filepath("colmap_dir") / "0" / name for name in self.COLMAP_SPARSE_FILES]
+            + [self.get_filepath("colmap_dir") / name for name in self.COLMAP_JSON_FILES]
+        )
+
+    def load_slam_poses(self):
+        """Load slam-poses.csv. Returns evo PoseTrajectory3D."""
+        from oxspires_tools.trajectory.file_interfaces.vilens_slam import VilensSlamTrajReader
+
+        return VilensSlamTrajReader(self.get_filepath("slam_poses")).read_file()
+
+    def load_gt_poses(self):
+        """Load GT TUM trajectory. Returns evo PoseTrajectory3D."""
+        from oxspires_tools.trajectory.file_interfaces.tum import TUMTrajReader
+
+        return TUMTrajReader(str(self.get_filepath("gt_tum"))).read_file()
+
+    def load_camera_timestamps(self, cam_id: int) -> list[TimeStamp]:
+        """Load TimeStamp objects for all images in a camera."""
+        timestamps = []
+        cam_dir = self.get_filepath(f"raw_cam{cam_id}")
+        for img_path in sorted(cam_dir.glob("*.jpg")):
+            try:
+                ts = TimeStamp(t_string=img_path.stem)
+                timestamps.append(ts)
+            except (AssertionError, ValueError):
+                continue
+        return timestamps
+
+    def parse_image_timestamps(self, cam_id: int) -> list[float]:
+        """Parse float timestamps from '{sec}.{nsec}.jpg' filenames."""
+        return [float(ts.t_float128) for ts in self.load_camera_timestamps(cam_id)]
+
+    def load_cloud_timestamps(self) -> list[TimeStamp]:
+        """Load TimeStamp objects for all undistorted LiDAR clouds."""
+        timestamps = []
+        lidar_dir = self.get_filepath("vilens_undist_clouds")
+        for pcd_path in sorted(lidar_dir.glob("*.pcd")):
+            try:
+                # Parse cloud_{sec}_{nsec} → {sec}.{nsec}
+                if not pcd_path.stem.startswith("cloud_"):
+                    continue
+                parts = pcd_path.stem[6:].rsplit("_", 1)
+                if len(parts) != 2 or not parts[0].isdigit() or not parts[1].isdigit():
+                    continue
+                if len(parts[0]) != 10 or len(parts[1]) != 9:
+                    continue
+                timestamp_str = f"{parts[0]}.{parts[1]}"
+                ts = TimeStamp(t_string=timestamp_str)
+                timestamps.append(ts)
+            except ValueError:
+                continue
+        return timestamps
+
+    def check_image_lidar_sync(self, cam_id: int = 0, tolerance_sec: float = 0.0) -> bool:
+        """Check if undistorted cloud timestamps are synchronized with camera images."""
+        image_timestamps = self.load_camera_timestamps(cam_id)
+        lidar_timestamps = self.load_cloud_timestamps()
+
+        if not image_timestamps:
+            logger.error(f"No images found in raw/cam{cam_id}")
+            return False
+
+        if not lidar_timestamps:
+            logger.error("No LiDAR point clouds found in processed/vilens-slam/undist-clouds")
+            return False
+
+        logger.info(f"Found {len(image_timestamps)} images, {len(lidar_timestamps)} LiDAR clouds")
+
+        unmatched: List[TimeStamp] = []
+        if tolerance_sec == 0.0:
+            image_ts_set = {ts.t_string for ts in image_timestamps}
+            for lidar_ts in lidar_timestamps:
+                if lidar_ts.t_string not in image_ts_set:
+                    unmatched.append(lidar_ts)
+        else:
+            image_floats = [float(ts.t_float128) for ts in image_timestamps]
+            for lidar_ts in lidar_timestamps:
+                lidar_float = float(lidar_ts.t_float128)
+                _, diff, _ = find_closest_in_sorted(image_floats, lidar_float)
+                if diff > tolerance_sec:
+                    unmatched.append(lidar_ts)
+
+        matched_count = len(lidar_timestamps) - len(unmatched)
+        logger.info(
+            f"Matched: {matched_count / len(lidar_timestamps) * 100:.2f}% ({matched_count}/{len(lidar_timestamps)}) LiDAR timestamps"
+        )
+
+        if unmatched:
+            logger.error(f"Unmatched LiDAR timestamps ({len(unmatched)}):")
+            for ts in unmatched[:10]:
+                logger.error(f"  {ts.t_string}")
+            if len(unmatched) > 10:
+                logger.error(f"  ... and {len(unmatched) - 10} more")
+            return False
+
+        logger.info("All LiDAR timestamps are synchronized with images")
+        return True

--- a/oxspires_tools/depth/main.py
+++ b/oxspires_tools/depth/main.py
@@ -38,6 +38,7 @@ def get_depth_from_cloud(
     depthmap, z_mask, u, v, sorted_indices = encode_points_as_depthmap(
         points_on_img, points_in_3d, h, w, is_euclidean, depth_factor
     )
+    normalmap = None
     if normals_np.size > 0:
         valid_normals_np = normals_np[mask_fov][in_image_mask][z_mask]
         valid_normals_np = valid_normals_np[sorted_indices]

--- a/oxspires_tools/utils.py
+++ b/oxspires_tools/utils.py
@@ -215,8 +215,7 @@ def get_image_pcd_sync_pair(
         ret = re.findall(r"\d+", it.name)
         timestamp = float(".".join(ret))
         image_timestamp, diff, _ = find_closest_in_sorted(image_timestamps, timestamp)
-        # print(diff)
-        if diff < timestamp_threshold:
+        if diff <= timestamp_threshold:
             image_pcd_pairs.append((image_paths[image_timestamp], it, diff))
 
     logger.info(f"Found {len(image_pcd_pairs)} image-pcd pairs")

--- a/oxspires_tools/utils.py
+++ b/oxspires_tools/utils.py
@@ -206,7 +206,7 @@ def get_image_pcd_sync_pair(
         timestamp = float(".".join(ret))
         image_timestamps.append(timestamp)
         image_paths[timestamp] = it
-    assert len(image_paths) > 0, "No images are found"
+    assert len(image_paths) > 0, f"No images are found in {image_dir}"
     logger.info(f"Loaded {len(image_paths)} images")
 
     # Collect all image and lidar pair which have timestamp close enough

--- a/scripts/dataset_download.py
+++ b/scripts/dataset_download.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 from huggingface_hub import snapshot_download
 
-from oxspires_tools.dataset import check_image_lidar_sync
+from oxspires_tools.dataset import OxfordSpiresDataset
 from oxspires_tools.utils import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -100,11 +100,8 @@ def main():
             if not seq_dir.is_dir():
                 continue
             logger.info(f"\n🚀 [{i}/{len(sequences_list)}] Checking sequence: {seq_dir.name}")
-            check_image_lidar_sync(
-                image_dir=seq_dir / "raw" / "cam0",
-                lidar_dir=seq_dir / "processed" / "vilens-slam" / "undist-clouds",
-                tolerance_sec=0.0,
-            )
+            dataset = OxfordSpiresDataset(seq_dir)
+            dataset.check_image_lidar_sync(cam_id=0, tolerance_sec=0.0)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -15,6 +15,85 @@ from oxspires_tools.utils import get_image_pcd_sync_pair, unzip_files
 logger = logging.getLogger(__name__)
 
 
+def setup_output_dirs(
+    proj_dir: Path,
+    depth_dir: str,
+    normal_dir: str,
+    camera_subdirs: list,
+    save_overlay: bool,
+    save_normal_map: bool,
+):
+    """Create all output directories (top-level and per-camera), removing any existing ones."""
+    overlay_dir = proj_dir / (depth_dir + "_overlay")
+    output_depth_dir = proj_dir / depth_dir
+    shutil.rmtree(output_depth_dir, ignore_errors=True)
+    if save_overlay:
+        shutil.rmtree(overlay_dir, ignore_errors=True)
+
+    output_normal_dir = None
+    if save_normal_map:
+        output_normal_dir = proj_dir / normal_dir
+        shutil.rmtree(output_normal_dir, ignore_errors=True)
+
+    for subdir in camera_subdirs:
+        (output_depth_dir / subdir).mkdir(parents=True, exist_ok=True)
+        if save_normal_map:
+            (output_normal_dir / subdir).mkdir(parents=True, exist_ok=True)
+        if save_overlay:
+            (overlay_dir / subdir).mkdir(parents=True, exist_ok=True)
+
+    return output_depth_dir, output_normal_dir, overlay_dir
+
+
+def preprocess_camera(
+    sensor,
+    cam_name: str,
+    subdir: str,
+    image_folder_path: str,
+    slam_individual_clouds_new_path: str,
+    output_depth_dir: Path,
+    output_normal_dir: Path,
+    overlay_dir: Path,
+    depth_pose_format: str,
+    depth_pose_path: str,
+    image_ext: str,
+    max_time_diff_camera_and_pose: float,
+    save_overlay: bool,
+    save_normal_map: bool,
+):
+    """Return camera params, transform, output subdirs, and synced image-pcd pairs."""
+    K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
+    T_cam_base = sensor.tf.get_transform("base", cam_name)
+
+    target_image_subdir = Path(image_folder_path) / subdir
+    target_depth_subdir = output_depth_dir / subdir
+    target_normal_subdir = output_normal_dir / subdir if save_normal_map else None
+    target_overlay_subdir = overlay_dir / subdir if save_overlay else None
+
+    logger.info(f"Target image directory: {target_image_subdir}")
+    logger.info(f"Target depth directory: {target_depth_subdir}")
+
+    image_pcd_pairs = get_image_pcd_sync_pair(
+        target_image_subdir,
+        slam_individual_clouds_new_path,
+        image_ext,
+        max_time_diff_camera_and_pose,
+    )
+
+    return (
+        K,
+        D,
+        h,
+        w,
+        fov_deg,
+        T_cam_base,
+        image_pcd_pairs,
+        target_depth_subdir,
+        target_normal_subdir,
+        target_overlay_subdir,
+    )
+
+
 def project_lidar_to_fisheye(
     sensor,
     project_dir: str,
@@ -22,129 +101,63 @@ def project_lidar_to_fisheye(
     normal_dir: str,
     camera_topics_labelled: dict,
     image_folder_path: str,
-    image_folder_name: str,
     depth_pose_format: str,
     slam_individual_clouds_new_path: str,
     is_euclidean: bool,
-    accum_length: int,
     max_time_diff_camera_and_pose: float,
     depth_pose_path: str = None,
-    image_ext: str = ".jpg",  # image extension
-    depth_factor: float = 256.0,  # depth encoding factor: (depth*depth_encode_factor).astype(np.uint16)",
+    image_ext: str = ".jpg",
+    depth_factor: float = 256.0,
     save_overlay: bool = True,
     save_normal_map: bool = True,
-    pose_scale_factor: float = 1.0,  # not 1 if colmap pose
     camera_model: str = "OPENCV_FISHEYE",
 ):
-    # args = get_args()
-    # Project dir
     proj_dir = Path(project_dir).expanduser()
 
     if is_euclidean:
         logger.info("Depth is euclidean: L2 distance between points and camera")
     else:
         logger.info("Depth is not euclidean: z_value")
-    # Path settings
-    # pcd_dir = proj_dir / "individual_clouds"
-    # image_dir = proj_dir / "images"
-    overlay_dir = proj_dir / (depth_dir + "_overlay")
-    output_depth_dir = proj_dir / depth_dir
-    if output_depth_dir.exists():
-        shutil.rmtree(output_depth_dir)
-    if save_overlay and overlay_dir.exists():
-        shutil.rmtree(overlay_dir)
-    output_depth_dir.mkdir(parents=True)
 
-    if save_normal_map:
-        output_normal_dir = proj_dir / normal_dir
-        if output_normal_dir.exists():
-            shutil.rmtree(output_normal_dir)
-        output_normal_dir.mkdir(parents=True)
+    if not image_ext.startswith("."):
+        image_ext = f".{image_ext}"
 
-    image_ext = image_ext if image_ext[0] == "." else f".{image_ext}"
-    cam_subdirs = list(camera_topics_labelled.values())
-    target_cam_names = list(camera_topics_labelled.keys())
+    output_depth_dir, output_normal_dir, overlay_dir = setup_output_dirs(
+        proj_dir, depth_dir, normal_dir, list(camera_topics_labelled.values()), save_overlay, save_normal_map
+    )
 
-    # Loop over each camera
-    for subdir, cam_name in zip(cam_subdirs, target_cam_names):
+    for cam_name, subdir in camera_topics_labelled.items():
         logger.info(f"Processing {cam_name} in {subdir} ...")
-        # Transformation from base to camera (clouds in individual_clouds are base coordinates)
-        # T_cam_lidar = np.linalg.inv(Ts[f"base_{cam_name}"]) @ Ts[f"base_{lidar_name}"]
-        K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
-        T_cam_base = sensor.tf.get_transform("base", cam_name)
+        K, D, h, w, fov_deg, T_cam_base, image_pcd_pairs, target_depth_subdir, target_normal_subdir, target_overlay_subdir = preprocess_camera(
+            sensor, cam_name, subdir, image_folder_path, slam_individual_clouds_new_path,
+            output_depth_dir, output_normal_dir, overlay_dir,
+            depth_pose_format, depth_pose_path, image_ext, max_time_diff_camera_and_pose,
+            save_overlay, save_normal_map,
+        )  # fmt: skip
 
-        # Setup input dir
-        target_image_subdir = Path(image_folder_path) / subdir
-        target_depth_subdir = Path(output_depth_dir) / subdir
-        target_depth_subdir.mkdir(parents=True, exist_ok=True)
-        if save_normal_map:
-            target_normal_subdir = Path(output_normal_dir) / subdir
-            target_normal_subdir.mkdir(parents=True, exist_ok=True)
-        if save_overlay:
-            target_overlay_subdir = Path(overlay_dir) / subdir
-            target_overlay_subdir.mkdir(parents=True, exist_ok=True)
-
-        # Project lidar points on images and  save as 16 bit depth
-        logger.info(f"Target image directory: {target_image_subdir}")
-        logger.info(f"Target depth directory: {target_depth_subdir}")
-
-        # Get image and pcd sync pairs
-        image_pcd_pairs = get_image_pcd_sync_pair(
-            target_image_subdir,
-            slam_individual_clouds_new_path,
-            image_ext,
-            max_time_diff_camera_and_pose,
-        )
-
-        # Loop for one camera
         logger.info(f"Fov: {fov_deg}")
-        # load all lidar poses as T_WB, so assume vilens-processed lidar in base frame
-        # T_WBs = get_transforms(
-        #     depth_pose_path,
-        #     depth_pose_format,
-        #     pose_scale_factor,
-        #     T_base_cam,
-        #     subdir,
-        #     image_folder_name,
-        #     frame="base",
-        #     visualise=False,
-        # )
-        for image_path, pcd_path, diff in tqdm(image_pcd_pairs):
-            # print(f"Processing {image_path} and {pcd_path} with diff={diff:.3f} sec")
-            # Load pointclouds
-            pcd = o3d.io.read_point_cloud(pcd_path.as_posix())
-            # pcd = get_accumulated_pcd(
-            #     pcd_path,
-            #     T_WBs,
-            #     accumulation_length=accum_length,
-            #     max_time_diff_camera_and_pose=max_time_diff_camera_and_pose,
-            # )
+        for image_path, pcd_path, _ in tqdm(image_pcd_pairs):
+            pcd = o3d.io.read_point_cloud(str(pcd_path))
             if pcd is None:
-                if accum_length == 0:
-                    logger.warning(f"{pcd_path} pose not found")
-                    continue
-                else:
-                    logger.error(f"{pcd_path} pose not found")
-                    raise RuntimeError()
-            # check if point cloud is empty
+                logger.warning(f"Failed to read {pcd_path}")
+                continue
             if len(pcd.points) == 0:
                 logger.warning(f"{pcd_path} is empty")
                 continue
-            # Transform points into camera coordinates
-            pcd.transform(T_cam_base)  # transform lidar points from base to camera frame
+            pcd.transform(T_cam_base)
             depth, normal = get_depth_from_cloud(pcd, K, D, w, h, fov_deg, camera_model, depth_factor, is_euclidean)
             save_projection_outputs(
                 depth,
                 normal,
                 image_path,
-                save_depth_path=(target_depth_subdir / (image_path.stem + ".png")).as_posix(),
-                save_normal_path=(target_normal_subdir / (image_path.stem + ".png")).as_posix(),
-                save_overlay_path=(target_overlay_subdir / (image_path.stem + ".jpg")).as_posix(),
+                save_depth_path=target_depth_subdir / (image_path.stem + ".png"),
+                save_normal_path=target_normal_subdir / (image_path.stem + ".png") if target_normal_subdir else None,
+                save_overlay_path=target_overlay_subdir / (image_path.stem + ".jpg") if target_overlay_subdir else None,
             )
 
 
 if __name__ == "__main__":
-    config_yaml_path = Path("/home/docker_dev/oxford_spires_dataset/config/sensor.yaml")
+    config_yaml_path = Path(__file__).parent.parent / "configs" / "sensor.yaml"
     with open(config_yaml_path, "r") as f:
         yaml_data = yaml.safe_load(f)
     sensor = Sensor(**yaml_data["sensor"])
@@ -165,28 +178,23 @@ if __name__ == "__main__":
         )
     zip_files = list(Path(local_dir).rglob("*.zip"))
     unzip_files(zip_files)
-    # remove the zip files after unzipping
     for zip_file in zip_files:
         zip_file.unlink()
 
     project_lidar_to_fisheye(
         sensor=sensor,
-        project_dir=str(local_dir/ "sequences/2024-03-18-christ-church-01/processed/oxspires_tools_outputs"),
+        project_dir=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/oxspires_tools_outputs"),
         depth_dir="depths_euc_accum_0",
         normal_dir="normals_euc_accum_0",
         camera_topics_labelled=sensor.camera_topics_labelled,
         image_folder_path=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/colmap"),
-        image_folder_name="images",
-        # depth_pose_path=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/colmap/transforms_colmap_scaled.json"),
         depth_pose_format="vilens_slam",
         slam_individual_clouds_new_path=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds"),
         is_euclidean=True,
-        accum_length=0,
         max_time_diff_camera_and_pose=0.025,
-        image_ext=".jpg",  # image extension
-        depth_factor=256.0,  # depth encoding factor: (depth*depth_encode_factor).astype(np.uint16)
+        image_ext=".jpg",
+        depth_factor=256.0,
         save_overlay=True,
         save_normal_map=True,
-        pose_scale_factor=1.0,  # not 1 if colmap pose
         camera_model="OPENCV_FISHEYE",
     )  # fmt: skip

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from oxspires_tools.depth.main import get_depth_from_cloud
 from oxspires_tools.depth.utils import save_projection_outputs
 from oxspires_tools.sensor import Sensor
-from oxspires_tools.utils import get_image_pcd_sync_pair
+from oxspires_tools.utils import get_image_pcd_sync_pair, setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +125,7 @@ def get_args():
 
 
 if __name__ == "__main__":
+    setup_logging()
     args = get_args()
 
     config_yaml_path = Path(__file__).parent.parent / "configs" / "sensor.yaml"

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -1,16 +1,16 @@
+import argparse
 import logging
 import shutil
 from pathlib import Path
 
 import open3d as o3d
 import yaml
-from huggingface_hub import snapshot_download
 from tqdm.auto import tqdm
 
 from oxspires_tools.depth.main import get_depth_from_cloud
 from oxspires_tools.depth.utils import save_projection_outputs
 from oxspires_tools.sensor import Sensor
-from oxspires_tools.utils import get_image_pcd_sync_pair, unzip_files
+from oxspires_tools.utils import get_image_pcd_sync_pair
 
 logger = logging.getLogger(__name__)
 
@@ -156,40 +156,37 @@ def project_lidar_to_fisheye(
             )
 
 
+def get_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Generate depth maps from LiDAR point clouds")
+    parser.add_argument(
+        "--sequence_dir",
+        type=str,
+        default="data/sequences/2024-03-18-christ-church-01",
+        help="Path to the sequence directory",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
+    args = get_args()
+
     config_yaml_path = Path(__file__).parent.parent / "configs" / "sensor.yaml"
     with open(config_yaml_path, "r") as f:
         yaml_data = yaml.safe_load(f)
     sensor = Sensor(**yaml_data["sensor"])
 
-    hf_repo_id = "ori-drs/oxford_spires_dataset"
-    download_patterns = [
-        "sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds.zip",
-        "sequences/2024-03-18-christ-church-01/processed/colmap/images.zip",
-    ]
-    local_dir = Path(__file__).parent.parent / "data" / "hf"
-    for pattern in download_patterns:
-        snapshot_download(
-            repo_id=hf_repo_id,
-            allow_patterns=pattern,
-            local_dir=local_dir,
-            repo_type="dataset",
-            use_auth_token=False,
-        )
-    zip_files = list(Path(local_dir).rglob("*.zip"))
-    unzip_files(zip_files)
-    for zip_file in zip_files:
-        zip_file.unlink()
+    seq_dir = Path(args.sequence_dir) / "processed"
 
     project_lidar_to_fisheye(
         sensor=sensor,
-        project_dir=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/oxspires_tools_outputs"),
+        project_dir=str(seq_dir / "oxspires_tools_outputs"),
         depth_dir="depths_euc_accum_0",
         normal_dir="normals_euc_accum_0",
         camera_topics_labelled=sensor.camera_topics_labelled,
-        image_folder_path=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/colmap"),
+        image_folder_path=str(seq_dir / "colmap"),
         depth_pose_format="vilens_slam",
-        slam_individual_clouds_new_path=str(local_dir / "sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds"),
+        slam_individual_clouds_new_path=str(seq_dir / "vilens-slam" / "undist-clouds"),
         is_euclidean=True,
         max_time_diff_camera_and_pose=0.025,
         image_ext=".jpg",

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -58,7 +58,6 @@ def project_lidar_to_fisheye(
     project_dir: str,
     depth_dir: str,
     normal_dir: str,
-    camera_topics_labelled: dict,
     image_folder_path: str,
     depth_pose_format: str,
     slam_individual_clouds_new_path: str,
@@ -78,13 +77,13 @@ def project_lidar_to_fisheye(
         Path(project_dir),
         depth_dir,
         normal_dir,
-        list(camera_topics_labelled.values()),
+        list(sensor.camera_topics_labelled.values()),
         image_folder_path,
         save_overlay,
         save_normal_map,
     )
 
-    for cam_name, subdir in camera_topics_labelled.items():
+    for cam_name, subdir in sensor.camera_topics_labelled.items():
         logger.info(f"Processing {cam_name} in {subdir} ...")
         target_image_subdir, target_depth_subdir, target_normal_subdir, target_overlay_subdir = target_subdirs[subdir]
         K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
@@ -94,11 +93,8 @@ def project_lidar_to_fisheye(
 
         for image_path, pcd_path, _ in tqdm(image_pcd_pairs):
             pcd = o3d.io.read_point_cloud(str(pcd_path))
-            if pcd is None:
-                logger.warning(f"Failed to read {pcd_path}")
-                continue
-            if len(pcd.points) == 0:
-                logger.warning(f"{pcd_path} is empty")
+            if pcd is None or len(pcd.points) == 0:
+                logger.warning(f"Skipping {pcd_path}: {'failed to read' if pcd is None else 'empty'}")
                 continue
             pcd.transform(T_cam_base)
             depth, normal = get_depth_from_cloud(pcd, K, D, w, h, fov_deg, camera_model, depth_factor, is_euclidean)
@@ -140,7 +136,6 @@ if __name__ == "__main__":
         project_dir=str(seq_dir / "processed" / "oxspires_tools_outputs"),
         depth_dir="depths_euc_accum_0",
         normal_dir="normals_euc_accum_0",
-        camera_topics_labelled=sensor.camera_topics_labelled,
         image_folder_path=str(seq_dir / "processed" / "colmap"),
         depth_pose_format="vilens_slam",
         slam_individual_clouds_new_path=str(seq_dir / "processed" / "vilens-slam" / "undist-clouds"),

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -20,6 +20,7 @@ def setup_output_dirs(
     depth_dir: str,
     normal_dir: str,
     camera_subdirs: list,
+    image_folder_path: str,
     save_overlay: bool,
     save_normal_map: bool,
 ):
@@ -35,63 +36,21 @@ def setup_output_dirs(
         output_normal_dir = proj_dir / normal_dir
         shutil.rmtree(output_normal_dir, ignore_errors=True)
 
+    target_subdirs = {}
     for subdir in camera_subdirs:
         (output_depth_dir / subdir).mkdir(parents=True, exist_ok=True)
         if save_normal_map:
             (output_normal_dir / subdir).mkdir(parents=True, exist_ok=True)
         if save_overlay:
             (overlay_dir / subdir).mkdir(parents=True, exist_ok=True)
+        target_subdirs[subdir] = (
+            Path(image_folder_path) / subdir,
+            output_depth_dir / subdir,
+            output_normal_dir / subdir if save_normal_map else None,
+            overlay_dir / subdir if save_overlay else None,
+        )
 
-    return output_depth_dir, output_normal_dir, overlay_dir
-
-
-def preprocess_camera(
-    sensor,
-    cam_name: str,
-    subdir: str,
-    image_folder_path: str,
-    slam_individual_clouds_new_path: str,
-    output_depth_dir: Path,
-    output_normal_dir: Path,
-    overlay_dir: Path,
-    depth_pose_format: str,
-    depth_pose_path: str,
-    image_ext: str,
-    max_time_diff_camera_and_pose: float,
-    save_overlay: bool,
-    save_normal_map: bool,
-):
-    """Return camera params, transform, output subdirs, and synced image-pcd pairs."""
-    K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
-    T_cam_base = sensor.tf.get_transform("base", cam_name)
-
-    target_image_subdir = Path(image_folder_path) / subdir
-    target_depth_subdir = output_depth_dir / subdir
-    target_normal_subdir = output_normal_dir / subdir if save_normal_map else None
-    target_overlay_subdir = overlay_dir / subdir if save_overlay else None
-
-    logger.info(f"Target image directory: {target_image_subdir}")
-    logger.info(f"Target depth directory: {target_depth_subdir}")
-
-    image_pcd_pairs = get_image_pcd_sync_pair(
-        target_image_subdir,
-        slam_individual_clouds_new_path,
-        image_ext,
-        max_time_diff_camera_and_pose,
-    )
-
-    return (
-        K,
-        D,
-        h,
-        w,
-        fov_deg,
-        T_cam_base,
-        image_pcd_pairs,
-        target_depth_subdir,
-        target_normal_subdir,
-        target_overlay_subdir,
-    )
+    return output_depth_dir, output_normal_dir, overlay_dir, target_subdirs
 
 
 def project_lidar_to_fisheye(
@@ -112,30 +71,27 @@ def project_lidar_to_fisheye(
     save_normal_map: bool = True,
     camera_model: str = "OPENCV_FISHEYE",
 ):
-    proj_dir = Path(project_dir).expanduser()
+    logger.info("Depth is euclidean: L2 distance between points and camera" if is_euclidean else "Depth is not euclidean: z_value")  # fmt: skip
+    image_ext = f".{image_ext}" if not image_ext.startswith(".") else image_ext
 
-    if is_euclidean:
-        logger.info("Depth is euclidean: L2 distance between points and camera")
-    else:
-        logger.info("Depth is not euclidean: z_value")
-
-    if not image_ext.startswith("."):
-        image_ext = f".{image_ext}"
-
-    output_depth_dir, output_normal_dir, overlay_dir = setup_output_dirs(
-        proj_dir, depth_dir, normal_dir, list(camera_topics_labelled.values()), save_overlay, save_normal_map
+    _, _, _, target_subdirs = setup_output_dirs(
+        Path(project_dir),
+        depth_dir,
+        normal_dir,
+        list(camera_topics_labelled.values()),
+        image_folder_path,
+        save_overlay,
+        save_normal_map,
     )
 
     for cam_name, subdir in camera_topics_labelled.items():
         logger.info(f"Processing {cam_name} in {subdir} ...")
-        K, D, h, w, fov_deg, T_cam_base, image_pcd_pairs, target_depth_subdir, target_normal_subdir, target_overlay_subdir = preprocess_camera(
-            sensor, cam_name, subdir, image_folder_path, slam_individual_clouds_new_path,
-            output_depth_dir, output_normal_dir, overlay_dir,
-            depth_pose_format, depth_pose_path, image_ext, max_time_diff_camera_and_pose,
-            save_overlay, save_normal_map,
-        )  # fmt: skip
-
+        target_image_subdir, target_depth_subdir, target_normal_subdir, target_overlay_subdir = target_subdirs[subdir]
+        K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
         logger.info(f"Fov: {fov_deg}")
+        T_cam_base = sensor.tf.get_transform("base", cam_name)
+        image_pcd_pairs = get_image_pcd_sync_pair(target_image_subdir, slam_individual_clouds_new_path, image_ext, max_time_diff_camera_and_pose)  # fmt: skip
+
         for image_path, pcd_path, _ in tqdm(image_pcd_pairs):
             pcd = o3d.io.read_point_cloud(str(pcd_path))
             if pcd is None:
@@ -176,17 +132,17 @@ if __name__ == "__main__":
         yaml_data = yaml.safe_load(f)
     sensor = Sensor(**yaml_data["sensor"])
 
-    seq_dir = Path(args.sequence_dir) / "processed"
+    seq_dir = Path(args.sequence_dir)
 
     project_lidar_to_fisheye(
         sensor=sensor,
-        project_dir=str(seq_dir / "oxspires_tools_outputs"),
+        project_dir=str(seq_dir / "processed" / "oxspires_tools_outputs"),
         depth_dir="depths_euc_accum_0",
         normal_dir="normals_euc_accum_0",
         camera_topics_labelled=sensor.camera_topics_labelled,
-        image_folder_path=str(seq_dir / "colmap"),
+        image_folder_path=str(seq_dir / "processed" / "colmap"),
         depth_pose_format="vilens_slam",
-        slam_individual_clouds_new_path=str(seq_dir / "vilens-slam" / "undist-clouds"),
+        slam_individual_clouds_new_path=str(seq_dir / "processed" / "vilens-slam" / "undist-clouds"),
         is_euclidean=True,
         max_time_diff_camera_and_pose=0.025,
         image_ext=".jpg",
@@ -194,4 +150,4 @@ if __name__ == "__main__":
         save_overlay=True,
         save_normal_map=True,
         camera_model="OPENCV_FISHEYE",
-    )  # fmt: skip
+    )


### PR DESCRIPTION
##  Summary

  - Refactor `generate_depth.py` to remove obsolete parameters and extract output directory setup into setup_output_dirs
  - Move HuggingFace download out of the script into a dedicated Taskfile task; replace hardcoded paths with `--sequence_dir` CLI arg
  - Add `OxfordSpiresDataset` class to centralise sequence path management, replacing the old `check_image_lidar_sync free` function            
                                                                                                                                            
##  Fix

  - depth/main.py: initialise normalmap = None before the normals guard to prevent NameError on empty normals                               
  - get_image_pcd_sync_pair: changed diff < threshold to diff <= threshold
                                                                                                        
##  Example usage
```bash
task download -- --patterns "sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds.zip" \
                            "sequences/2024-03-18-christ-church-01/processed/colmap/images.zip"
task generate_depth -- --sequence_dir data/sequences/2024-03-18-christ-church-01  
```