### PR TITLE
refactor: simplify depth generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ BUILD_CPP=1 pip install .
 <img src="docs/overlay.png" height="300" />
 
 The following scripts download synchronised images and lidar from a sequence in HuggingFace, and generates depth image, lidar overlaid on camera and surface normal images.
-```
-python scripts/dataset_download.py --patterns "sequences/2024-03-12-keble-college-02/processed/colmap/images.zip" "sequences/2024-03-12-keble-college-02/processed/vilens-slam/undist-clouds.zip"
-python scripts/generate_depth.py --sequence_dir data/sequences/2024-03-12-keble-college-02
+```bash
+python scripts/dataset_download.py --patterns "sequences/2024-03-18-christ-church-01/processed/colmap/images.zip" "sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds.zip"
+python scripts/generate_depth.py \
+  --image_folder_path data/sequences/2024-03-18-christ-church-01/processed/colmap \
+  --clouds_path data/sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds \
+  --output_dir outputs/sequences/2024-03-18-christ-church-01/
 ```
 
 ## Localisation Benchmark

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ BUILD_CPP=1 pip install .
 
 The following scripts download synchronised images and lidar from a sequence in HuggingFace, and generates depth image, lidar overlaid on camera and surface normal images.
 ```
-python scripts/generate_depth.py
+python scripts/dataset_download.py --patterns "sequences/2024-03-12-keble-college-02/processed/colmap/images.zip" "sequences/2024-03-12-keble-college-02/processed/vilens-slam/undist-clouds.zip"
+python scripts/generate_depth.py --sequence_dir data/sequences/2024-03-12-keble-college-02
 ```
 
 ## Localisation Benchmark

--- a/oxspires_tools/depth/utils.py
+++ b/oxspires_tools/depth/utils.py
@@ -69,11 +69,14 @@ def save_projection_outputs(
     camera_image = cv2.imread(Path(image_path).as_posix()) if image_path else None
 
     if save_depth_path:
+        Path(save_depth_path).parent.mkdir(parents=True, exist_ok=True)
         cv2.imwrite(str(save_depth_path), depthmap)
     if save_normal_path and normalmap is not None:
+        Path(save_normal_path).parent.mkdir(parents=True, exist_ok=True)
         normalmap = cv2.cvtColor(normalmap, cv2.COLOR_RGB2BGR)
         cv2.imwrite(str(save_normal_path), normalmap)
     if save_overlay_path:
         assert camera_image is not None
+        Path(save_overlay_path).parent.mkdir(parents=True, exist_ok=True)
         overlay = get_overlay(camera_image, depthmap)
         cv2.imwrite(str(save_overlay_path), overlay)

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_args():
-    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Generate depth maps from LiDAR point clouds")
     parser.add_argument("--image_folder_path", type=str, required=True)
     parser.add_argument("--clouds_path", type=str, required=True)
     parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--max_time_diff", type=float, default=None)
     parser.add_argument("--euclidean", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--depth_factor", type=float, default=256.0)
     parser.add_argument("--accum_number", type=int, default=0)
@@ -36,8 +36,7 @@ if __name__ == "__main__":
         yaml_data = yaml.safe_load(f)
     sensor = Sensor(**yaml_data["sensor"])
 
-    max_time_diff = sensor.max_time_diff_camera_and_pose
-
+    max_time_diff = args.max_time_diff if args.max_time_diff is not None else sensor.max_time_diff_camera_and_pose
     depth_tag = "euc" if args.euclidean else "z"
     proj_dir = Path(args.output_dir)
     output_depth_dir = proj_dir / f"depths_{depth_tag}_accum_{args.accum_number}"

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -15,44 +15,6 @@ from oxspires_tools.utils import get_image_pcd_sync_pair, setup_logging
 logger = logging.getLogger(__name__)
 
 
-def setup_output_dirs(
-    proj_dir: Path,
-    depth_dir: str,
-    normal_dir: str,
-    camera_subdirs: list,
-    image_folder_path: str,
-    save_overlay: bool,
-    save_normal_map: bool,
-):
-    """Create all output directories (top-level and per-camera), removing any existing ones."""
-    overlay_dir = proj_dir / (depth_dir + "_overlay")
-    output_depth_dir = proj_dir / depth_dir
-    shutil.rmtree(output_depth_dir, ignore_errors=True)
-    if save_overlay:
-        shutil.rmtree(overlay_dir, ignore_errors=True)
-
-    output_normal_dir = None
-    if save_normal_map:
-        output_normal_dir = proj_dir / normal_dir
-        shutil.rmtree(output_normal_dir, ignore_errors=True)
-
-    target_subdirs = {}
-    for subdir in camera_subdirs:
-        (output_depth_dir / subdir).mkdir(parents=True, exist_ok=True)
-        if save_normal_map:
-            (output_normal_dir / subdir).mkdir(parents=True, exist_ok=True)
-        if save_overlay:
-            (overlay_dir / subdir).mkdir(parents=True, exist_ok=True)
-        target_subdirs[subdir] = (
-            Path(image_folder_path) / subdir,
-            output_depth_dir / subdir,
-            output_normal_dir / subdir if save_normal_map else None,
-            overlay_dir / subdir if save_overlay else None,
-        )
-
-    return output_depth_dir, output_normal_dir, overlay_dir, target_subdirs
-
-
 def project_lidar_to_fisheye(
     sensor,
     project_dir: str,
@@ -73,23 +35,22 @@ def project_lidar_to_fisheye(
     logger.info("Depth is euclidean: L2 distance between points and camera" if is_euclidean else "Depth is not euclidean: z_value")  # fmt: skip
     image_ext = f".{image_ext}" if not image_ext.startswith(".") else image_ext
 
-    _, _, _, target_subdirs = setup_output_dirs(
-        Path(project_dir),
-        depth_dir,
-        normal_dir,
-        list(sensor.camera_topics_labelled.values()),
-        image_folder_path,
-        save_overlay,
-        save_normal_map,
-    )
+    proj_dir = Path(project_dir)
+    output_depth_dir = proj_dir / depth_dir
+    output_normal_dir = proj_dir / normal_dir if save_normal_map else None
+    overlay_dir = proj_dir / (depth_dir + "_overlay") if save_overlay else None
+    shutil.rmtree(output_depth_dir, ignore_errors=True)
+    if output_normal_dir:
+        shutil.rmtree(output_normal_dir, ignore_errors=True)
+    if overlay_dir:
+        shutil.rmtree(overlay_dir, ignore_errors=True)
 
     for cam_name, subdir in sensor.camera_topics_labelled.items():
         logger.info(f"Processing {cam_name} in {subdir} ...")
-        target_image_subdir, target_depth_subdir, target_normal_subdir, target_overlay_subdir = target_subdirs[subdir]
         K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
         logger.info(f"Fov: {fov_deg}")
         T_cam_base = sensor.tf.get_transform("base", cam_name)
-        image_pcd_pairs = get_image_pcd_sync_pair(target_image_subdir, slam_individual_clouds_new_path, image_ext, max_time_diff_camera_and_pose)  # fmt: skip
+        image_pcd_pairs = get_image_pcd_sync_pair(Path(image_folder_path) / subdir, slam_individual_clouds_new_path, image_ext, max_time_diff_camera_and_pose)  # fmt: skip
 
         for image_path, pcd_path, _ in tqdm(image_pcd_pairs):
             pcd = o3d.io.read_point_cloud(str(pcd_path))
@@ -102,9 +63,9 @@ def project_lidar_to_fisheye(
                 depth,
                 normal,
                 image_path,
-                save_depth_path=target_depth_subdir / (image_path.stem + ".png"),
-                save_normal_path=target_normal_subdir / (image_path.stem + ".png") if target_normal_subdir else None,
-                save_overlay_path=target_overlay_subdir / (image_path.stem + ".jpg") if target_overlay_subdir else None,
+                save_depth_path=output_depth_dir / subdir / (image_path.stem + ".png"),
+                save_normal_path=output_normal_dir / subdir / (image_path.stem + ".png") if output_normal_dir else None,
+                save_overlay_path=overlay_dir / subdir / (image_path.stem + ".jpg") if overlay_dir else None,
             )
 
 

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -15,69 +15,15 @@ from oxspires_tools.utils import get_image_pcd_sync_pair, setup_logging
 logger = logging.getLogger(__name__)
 
 
-def project_lidar_to_fisheye(
-    sensor,
-    project_dir: str,
-    depth_dir: str,
-    normal_dir: str,
-    image_folder_path: str,
-    depth_pose_format: str,
-    slam_individual_clouds_new_path: str,
-    is_euclidean: bool,
-    max_time_diff_camera_and_pose: float,
-    depth_pose_path: str = None,
-    image_ext: str = ".jpg",
-    depth_factor: float = 256.0,
-    save_overlay: bool = True,
-    save_normal_map: bool = True,
-    camera_model: str = "OPENCV_FISHEYE",
-):
-    logger.info("Depth is euclidean: L2 distance between points and camera" if is_euclidean else "Depth is not euclidean: z_value")  # fmt: skip
-    image_ext = f".{image_ext}" if not image_ext.startswith(".") else image_ext
-
-    proj_dir = Path(project_dir)
-    output_depth_dir = proj_dir / depth_dir
-    output_normal_dir = proj_dir / normal_dir if save_normal_map else None
-    overlay_dir = proj_dir / (depth_dir + "_overlay") if save_overlay else None
-    shutil.rmtree(output_depth_dir, ignore_errors=True)
-    if output_normal_dir:
-        shutil.rmtree(output_normal_dir, ignore_errors=True)
-    if overlay_dir:
-        shutil.rmtree(overlay_dir, ignore_errors=True)
-
-    for cam_name, subdir in sensor.camera_topics_labelled.items():
-        logger.info(f"Processing {cam_name} in {subdir} ...")
-        K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, depth_pose_format, depth_pose_path)
-        logger.info(f"Fov: {fov_deg}")
-        T_cam_base = sensor.tf.get_transform("base", cam_name)
-        image_pcd_pairs = get_image_pcd_sync_pair(Path(image_folder_path) / subdir, slam_individual_clouds_new_path, image_ext, max_time_diff_camera_and_pose)  # fmt: skip
-
-        for image_path, pcd_path, _ in tqdm(image_pcd_pairs):
-            pcd = o3d.io.read_point_cloud(str(pcd_path))
-            if pcd is None or len(pcd.points) == 0:
-                logger.warning(f"Skipping {pcd_path}: {'failed to read' if pcd is None else 'empty'}")
-                continue
-            pcd.transform(T_cam_base)
-            depth, normal = get_depth_from_cloud(pcd, K, D, w, h, fov_deg, camera_model, depth_factor, is_euclidean)
-            save_projection_outputs(
-                depth,
-                normal,
-                image_path,
-                save_depth_path=output_depth_dir / subdir / (image_path.stem + ".png"),
-                save_normal_path=output_normal_dir / subdir / (image_path.stem + ".png") if output_normal_dir else None,
-                save_overlay_path=overlay_dir / subdir / (image_path.stem + ".jpg") if overlay_dir else None,
-            )
-
-
 def get_args():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Generate depth maps from LiDAR point clouds")
-    parser.add_argument(
-        "--sequence_dir",
-        type=str,
-        default="data/sequences/2024-03-18-christ-church-01",
-        help="Path to the sequence directory",
-    )
+    parser.add_argument("--image_folder_path", type=str, required=True)
+    parser.add_argument("--clouds_path", type=str, required=True)
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--euclidean", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--depth_factor", type=float, default=256.0)
+    parser.add_argument("--accum_number", type=int, default=0)
     return parser.parse_args()
 
 
@@ -90,21 +36,38 @@ if __name__ == "__main__":
         yaml_data = yaml.safe_load(f)
     sensor = Sensor(**yaml_data["sensor"])
 
-    seq_dir = Path(args.sequence_dir)
+    max_time_diff = sensor.max_time_diff_camera_and_pose
 
-    project_lidar_to_fisheye(
-        sensor=sensor,
-        project_dir=str(seq_dir / "processed" / "oxspires_tools_outputs"),
-        depth_dir="depths_euc_accum_0",
-        normal_dir="normals_euc_accum_0",
-        image_folder_path=str(seq_dir / "processed" / "colmap"),
-        depth_pose_format="vilens_slam",
-        slam_individual_clouds_new_path=str(seq_dir / "processed" / "vilens-slam" / "undist-clouds"),
-        is_euclidean=True,
-        max_time_diff_camera_and_pose=0.025,
-        image_ext=".jpg",
-        depth_factor=256.0,
-        save_overlay=True,
-        save_normal_map=True,
-        camera_model="OPENCV_FISHEYE",
-    )
+    depth_tag = "euc" if args.euclidean else "z"
+    proj_dir = Path(args.output_dir)
+    output_depth_dir = proj_dir / f"depths_{depth_tag}_accum_{args.accum_number}"
+    output_normal_dir = proj_dir / f"normals_{depth_tag}_accum_{args.accum_number}"
+    overlay_dir = proj_dir / f"depths_{depth_tag}_accum_{args.accum_number}_overlay"
+    for d in (output_depth_dir, output_normal_dir, overlay_dir):
+        shutil.rmtree(d, ignore_errors=True)
+
+    logger.info("Depth is euclidean: L2 distance between points and camera" if args.euclidean else "Depth is z-value")
+    for cam_name, subdir in sensor.camera_topics_labelled.items():
+        logger.info(f"Processing {cam_name} in {subdir} ...")
+        K, D, h, w, fov_deg, _ = sensor.get_params_for_depth(cam_name, "vilens_slam", None)
+        logger.info(f"Fov: {fov_deg}")
+        T_cam_base = sensor.tf.get_transform("base", cam_name)
+        image_pcd_pairs = get_image_pcd_sync_pair(Path(args.image_folder_path) / subdir, Path(args.clouds_path), ".jpg", max_time_diff)  # fmt: skip
+
+        for image_path, pcd_path, _ in tqdm(image_pcd_pairs):
+            pcd = o3d.io.read_point_cloud(str(pcd_path))
+            if pcd is None or len(pcd.points) == 0:
+                logger.warning(f"Skipping {pcd_path}: {'failed to read' if pcd is None else 'empty'}")
+                continue
+            pcd.transform(T_cam_base)
+            depth, normal = get_depth_from_cloud(
+                pcd, K, D, w, h, fov_deg, "OPENCV_FISHEYE", args.depth_factor, args.euclidean
+            )
+            save_projection_outputs(
+                depth,
+                normal,
+                image_path,
+                save_depth_path=output_depth_dir / subdir / (image_path.stem + ".png"),
+                save_normal_path=output_normal_dir / subdir / (image_path.stem + ".png"),
+                save_overlay_path=overlay_dir / subdir / (image_path.stem + ".jpg"),
+            )


### PR DESCRIPTION
Follows #69 

## Summary
- Replaced `--sequence_dir` with explicit `--image_folder_path`, `--clouds_path`, and `--output_dir` args for more flexible usage
- Removed `setup_output_dirs` and `project_lidar_to_fisheye` wrapper functions; inlined logic directly into `__main__`    
- Added `--max_time_diff`, `--euclidean`, `--depth_factor`, and `--accum_number` as CLI args                                
- Auto-creates output directories in `save_projection_outputs` instead of requiring pre-setup

## Example usage   
```python
python3 scripts/generate_depth.py \
	--image_folder_path data/sequences/2024-03-18-christ-church-01/processed/colmap \
	--clouds_path data/sequences/2024-03-18-christ-church-01/processed/vilens-slam/undist-clouds \
	--output_dir data/sequences/2024-03-18-christ-church-01/processed/oxspires_tools_outputs \
	--max_time_diff 0.025 \
	--accum_number 0
```