### PR TITLE
  Refactor eval pipeline and fix evo imports

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,12 @@ tasks:
     cmds:
       - "python scripts/dataset_download.py {{.CLI_ARGS}}"
 
+
+  eval_cloud:
+    desc: "Evaluate a single cloud against GT -- INPUT_CLOUD=... GT_CLOUD=... OUTPUT_JSON=..."
+    cmds:
+      - python scripts/eval_cloud.py --input_cloud {{.INPUT_CLOUD}} --gt_cloud {{.GT_CLOUD}} --output_json {{.OUTPUT_JSON}} {{.CLI_ARGS}}
+
   generate_depth:
     desc: Generate depth maps -- e.g. task generate_depth -- --sequence_dir data/sequences/2024-03-18-christ-church-01
     cmds:

--- a/oxspires_tools/eval.py
+++ b/oxspires_tools/eval.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 from pathlib import Path
 
@@ -10,31 +11,79 @@ from scipy.spatial import cKDTree as KDTree
 logger = logging.getLogger(__name__)
 
 
-def compute_p2p_distance(query_cloud: np.ndarray, reference_cloud: np.ndarray):
+def compute_p2p_distance(query_cloud: np.ndarray, reference_cloud: np.ndarray, max_distance=np.inf):
     ref_kd_tree = KDTree(reference_cloud)
-    distances, _ = ref_kd_tree.query(query_cloud, workers=-1)
+    distances, _ = ref_kd_tree.query(query_cloud, workers=-1, distance_upper_bound=max_distance)
     return distances
 
 
-def get_recon_metrics(
+def get_threshold_ratio(error_array, threshold):
+    assert isinstance(error_array, np.ndarray)
+    assert error_array.ndim == 1
+    assert error_array.shape[0] > 0
+    assert isinstance(threshold, (int, float))
+    assert threshold > 0
+
+    return np.sum(error_array < threshold) / len(error_array)
+
+
+def compute_f1_score(precision: float, recall: float):
+    assert precision >= 0 and precision <= 1
+    assert recall >= 0 and recall <= 1
+    if precision + recall == 0:
+        return 0
+    f1_score = 2 * (precision * recall) / (precision + recall)
+    return f1_score
+
+
+def get_distances(
     input_cloud: np.ndarray,
     gt_cloud: np.ndarray,
-    precision_threshold=0.05,
-    recall_threshold=0.05,
+    compute_precision=True,
+    compute_recall=True,
+    max_distance=np.inf,
 ):
     assert isinstance(input_cloud, np.ndarray) and isinstance(gt_cloud, np.ndarray)
     assert input_cloud.shape[1] == 3 and gt_cloud.shape[1] == 3
-    logger.debug(f"Computing Accuracy and Precision ({precision_threshold}) ...")
-    distances = compute_p2p_distance(input_cloud, gt_cloud)
-    accuracy = np.mean(distances)
-    precision = np.sum(distances < precision_threshold) / len(distances)
+    if input_cloud.shape[0] == 0:
+        logger.warning("Input cloud is empty")
+        return None
+    if gt_cloud.shape[0] == 0:
+        logger.warning("GT cloud is empty")
+        return None
+    distance_precision = None
+    distance_recall = None
+    if compute_precision:
+        distance_precision = compute_p2p_distance(input_cloud, gt_cloud, max_distance=max_distance)
+    if compute_recall:
+        distance_recall = compute_p2p_distance(gt_cloud, input_cloud, max_distance=max_distance)
+    return distance_precision, distance_recall
 
-    logger.debug(f"Computing Completeness and Recall ({recall_threshold}) ...")
-    distances = compute_p2p_distance(gt_cloud, input_cloud)
-    completeness = np.mean(distances)
-    recall = np.sum(distances < recall_threshold) / len(distances)
-    f1_score = 2 * (precision * recall) / (precision + recall)
 
+def get_recon_metrics_from_dist(
+    distances_acc: np.ndarray,
+    distances_cmpl: np.ndarray,
+    precision_threshold=0.05,
+    recall_threshold=0.05,
+):
+    accuracy, precision, completeness, recall, f1_score = None, None, None, None, None
+    if distances_acc is not None:
+        assert isinstance(distances_acc, np.ndarray)
+        assert distances_acc.ndim == 1
+        assert distances_acc.shape[0] > 0
+        # assert distances_acc >= 0
+        assert np.all(distances_acc >= 0)
+        accuracy = np.mean(distances_acc)
+        precision = get_threshold_ratio(distances_acc, precision_threshold)
+    if distances_cmpl is not None:
+        assert isinstance(distances_cmpl, np.ndarray)
+        assert distances_cmpl.ndim == 1
+        assert distances_cmpl.shape[0] > 0
+        assert np.all(distances_cmpl >= 0)
+        completeness = np.mean(distances_cmpl)
+        recall = get_threshold_ratio(distances_cmpl, recall_threshold)
+    if distances_acc is not None and distances_cmpl is not None:
+        f1_score = compute_f1_score(precision, recall)
     results = {
         "accuracy": accuracy,
         "precision": precision,
@@ -45,58 +94,95 @@ def get_recon_metrics(
     return results
 
 
-def get_recon_metrics_multi_thresholds(
-    input_cloud: np.ndarray, gt_cloud: np.ndarray, thresholds: list = [0.02, 0.05, 0.1], max_distance=9999.0
+def get_recon_metrics(
+    input_cloud: np.ndarray,
+    gt_cloud: np.ndarray,
+    precision_threshold=0.05,
+    recall_threshold=0.05,
+    compute_precision=True,
+    compute_recall=True,
+    save_error_cloud_dir=None,
+    csv_path=None,
+    max_distance=np.inf,
 ):
     assert isinstance(input_cloud, np.ndarray) and isinstance(gt_cloud, np.ndarray)
     assert input_cloud.shape[1] == 3 and gt_cloud.shape[1] == 3
-    results = []
+    if input_cloud.shape[0] == 0:
+        logger.warning("Input cloud is empty")
+        return None
 
-    logger.debug("Computing Accuracy and Precision ...")
-    input_to_gt_dist = compute_p2p_distance(input_cloud, gt_cloud)
-    input_to_gt_dist = input_to_gt_dist[input_to_gt_dist <= max_distance]
-    accuracy = np.mean(input_to_gt_dist)
+    distance_precision, distance_recall = get_distances(
+        input_cloud,
+        gt_cloud,
+        compute_precision=compute_precision,
+        compute_recall=compute_recall,
+        max_distance=max_distance,
+    )
+    results = get_recon_metrics_from_dist(
+        distances_acc=distance_precision,
+        distances_cmpl=distance_recall,
+        precision_threshold=precision_threshold,
+        recall_threshold=recall_threshold,
+    )
 
-    logger.debug("Computing Completeness and Recall ...")
-    gt_to_input_dist = compute_p2p_distance(gt_cloud, input_cloud)
-    gt_to_input_dist = gt_to_input_dist[gt_to_input_dist <= max_distance]
-    completeness = np.mean(gt_to_input_dist)
+    if save_error_cloud_dir:
+        if compute_precision:
+            save_error_cloud(
+                input_cloud,
+                Path(save_error_cloud_dir) / "input_error_cloud.ply",
+                distances=distance_precision,
+                max_distance=max_distance,
+            )
+        # if compute_recall:
+        #     save_error_cloud(gt_cloud, Path(save_error_cloud_dir) / f"gt_error_cloud.ply", distance_recall, max_distance)
+    if csv_path:
+        if Path(csv_path).exists():
+            Path(csv_path).unlink()
+        dict_to_csv({**results}, csv_path)
 
-    logger.info(f"Accuracy: {accuracy:.4f}, Completeness: {completeness:.4f}")
-    results.append({"accuracy": accuracy, "completeness": completeness})
-    for threshold in thresholds:
-        precision = np.sum(input_to_gt_dist < threshold) / len(input_to_gt_dist)
-        recall = np.sum(gt_to_input_dist < threshold) / len(gt_to_input_dist)
-        f1_score = 2 * (precision * recall) / (precision + recall)
-        results.append(
-            {
-                "threshold": threshold,
-                "precision": precision,
-                "recall": recall,
-                "f1_score": f1_score,
-            }
-        )
-        logger.info(f"threshold {threshold} m, precision: {precision:.4f}, recall: {recall:.4f}, f1: {f1_score:.4f}")
     return results
 
 
-def save_error_cloud(input_cloud: np.ndarray, reference_cloud: np.ndarray, save_path, cmap="bgyr", max_distance=2.0):
-    def get_BGYR_colourmap():
-        colours = [
-            (0, 0, 255),  # Blue
-            (0, 255, 0),  # Green (as specified)
-            (255, 255, 0),  # Yellow (as specified)
-            (255, 0, 0),  # Red
-        ]
-        colours = [(r / 255, g / 255, b / 255) for r, g, b in colours]
+def dict_to_csv(dict_data, filename):
+    with open(filename, "a", newline="") as output_file:
+        dict_writer = csv.writer(output_file)
+        dict_writer.writerow(dict_data.keys())
+        dict_writer.writerow(dict_data.values())
 
-        # Create the custom colormap
-        n_bins = 100  # Number of color segments
-        cmap = LinearSegmentedColormap.from_list("custom_cmap", colours, N=n_bins)
-        return cmap
 
-    distances = compute_p2p_distance(input_cloud, reference_cloud)
-    input_cloud = input_cloud[distances <= max_distance]
+def get_BGYR_colourmap():
+    colours = [
+        (0, 0, 255),  # Blue
+        (0, 255, 0),  # Green (as specified)
+        (255, 255, 0),  # Yellow (as specified)
+        (255, 0, 0),  # Red
+    ]
+    colours = [(r / 255, g / 255, b / 255) for r, g, b in colours]
+
+    # Create the custom colormap
+    n_bins = 100  # Number of color segments
+    cmap = LinearSegmentedColormap.from_list("custom_cmap", colours, N=n_bins)
+    return cmap
+
+
+def save_error_cloud(
+    input_cloud_np: np.ndarray,
+    save_path,
+    reference_cloud_np: np.ndarray = None,
+    distances=None,
+    cmap="bgyr",
+    max_distance=np.inf,
+):
+    assert isinstance(input_cloud_np, np.ndarray)
+    assert (isinstance(distances, np.ndarray) and input_cloud_np.shape[0] == distances.shape[0]) or isinstance(
+        reference_cloud_np, np.ndarray
+    )
+    if input_cloud_np.shape[0] == 0:
+        logger.warning("Input cloud is empty")
+        return
+    if distances is None:
+        distances = compute_p2p_distance(input_cloud_np, reference_cloud_np)
+    input_cloud_np = input_cloud_np[distances <= max_distance]
     distances = distances[distances <= max_distance]
     distances = np.clip(distances, 0, 1)
     if cmap == "bgyr":
@@ -106,10 +192,10 @@ def save_error_cloud(input_cloud: np.ndarray, reference_cloud: np.ndarray, save_
         distances_cmap = plt.get_cmap(cmap)(distances / np.max(distances))
 
     test_cloud = o3d.geometry.PointCloud()
-    test_cloud.points = o3d.utility.Vector3dVector(input_cloud)
+    test_cloud.points = o3d.utility.Vector3dVector(input_cloud_np)
     test_cloud.colors = o3d.utility.Vector3dVector(distances_cmap[:, :3])
-    o3d.io.write_point_cloud(save_path, test_cloud)
-    logger.info(f"diff cloud saved to {save_path}")
+    o3d.io.write_point_cloud(str(save_path), test_cloud)
+    logger.debug(f"diff cloud saved to {save_path}")
 
 
 if __name__ == "__main__":

--- a/oxspires_tools/trajectory/file_interfaces/nerf.py
+++ b/oxspires_tools/trajectory/file_interfaces/nerf.py
@@ -4,9 +4,8 @@ import logging
 from copy import deepcopy
 from pathlib import Path
 
-import evo
 import numpy as np
-from evo.core.trajectory import PosePath3D
+from evo.core.trajectory import PosePath3D, PoseTrajectory3D
 
 from .base import BasicTrajReader, BasicTrajWriter
 from .timestamp import TimeStamp
@@ -57,9 +56,9 @@ class NeRFTrajReader(BasicTrajReader):
                 sort_idx = np.argsort(timestamps)
                 timestamps = timestamps[sort_idx]
                 poses_se3 = poses_se3[sort_idx]
-            return evo.core.trajectory.PoseTrajectory3D(poses_se3=poses_se3, timestamps=timestamps)
+            return PoseTrajectory3D(poses_se3=poses_se3, timestamps=timestamps)
 
-        return evo.core.trajectory.PosePath3D(poses_se3=poses_se3)
+        return PosePath3D(poses_se3=poses_se3)
 
 
 class NeRFTrajWriter(BasicTrajWriter):

--- a/oxspires_tools/trajectory/file_interfaces/tum.py
+++ b/oxspires_tools/trajectory/file_interfaces/tum.py
@@ -6,8 +6,9 @@ TUM format: https://vision.in.tum.de/data/datasets/rgbd-dataset/file_formats
 import logging
 import os
 
-import evo
 import numpy as np
+from evo.core.trajectory import PoseTrajectory3D
+from evo.tools.file_interface import read_tum_trajectory_file
 
 from .base import BasicTrajReader, BasicTrajWriter
 from .timestamp import TimeStamp
@@ -31,7 +32,7 @@ class TUMTrajReader(BasicTrajReader):
         """Read TUM trajectory file."""
         if self.reader_type == "evo":
             logger.info("Try to load TUM pose using evo; Assuming file name is timestamp")
-            tum_pose = evo.tools.file_interface.read_tum_trajectory_file(self.file_path)
+            tum_pose = read_tum_trajectory_file(self.file_path)
             assert tum_pose.check()[0] is True, tum_pose.check()[1]
         elif self.reader_type == "custom":
             logger.info("Try to load TUM pose using custom reader; Assuming file name is not timestamp")
@@ -88,7 +89,7 @@ class TUMTrajReader(BasicTrajReader):
         quat = np.array(quat)
         timestamps = np.array(time_stamp)
 
-        return evo.core.trajectory.PoseTrajectory3D(xyz, quat, timestamps=timestamps)
+        return PoseTrajectory3D(xyz, quat, timestamps=timestamps)
 
 
 class TUMTrajWriter(BasicTrajWriter):
@@ -104,7 +105,7 @@ class TUMTrajWriter(BasicTrajWriter):
         """Write custom TUM trajectory file with optional timestamp prefix/suffix."""
         if prefix != "" or suffix != "":
             logger.info(f'Assuming file name is timestamp in the format: "{prefix}<secs.nsecs>{suffix}"')
-        if not isinstance(pose, evo.core.trajectory.PoseTrajectory3D):
+        if not isinstance(pose, PoseTrajectory3D):
             logger.error(f"pose should be PoseTrajectory3D from evo, got: {type(pose)}")
             raise ValueError()
         if not os.path.exists(os.path.dirname(file_path)):

--- a/oxspires_tools/trajectory/file_interfaces/vilens_slam.py
+++ b/oxspires_tools/trajectory/file_interfaces/vilens_slam.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-import evo
 import numpy as np
+from evo.core.trajectory import PoseTrajectory3D
 from evo.tools.file_interface import csv_read_matrix
 
 from .base import BasicTrajReader, BasicTrajWriter
@@ -28,7 +28,7 @@ class VilensSlamTrajReader(BasicTrajReader):
         xyz = mat[:, 3:6]
         quat_xyzw = mat[:, 6:10]
         quat_wxyz = np.roll(quat_xyzw, 1, axis=1)  # xyzw -> wxyz
-        return evo.core.trajectory.PoseTrajectory3D(xyz, quat_wxyz, timestamps=timestamps)
+        return PoseTrajectory3D(xyz, quat_wxyz, timestamps=timestamps)
 
 
 class VilensSlamTrajWriter(BasicTrajWriter):
@@ -40,7 +40,7 @@ class VilensSlamTrajWriter(BasicTrajWriter):
     def write_file(self, pose):
         """Write trajectory in CSV style VILENS SLAM format."""
 
-        if not isinstance(pose, evo.core.trajectory.PoseTrajectory3D):
+        if not isinstance(pose, PoseTrajectory3D):
             logger.error(f"pose should be PoseTrajectory3D from evo, got: {type(pose)}")
             raise ValueError()
         if not os.path.exists(os.path.dirname(self.file_path)):

--- a/scripts/eval_cloud.py
+++ b/scripts/eval_cloud.py
@@ -39,6 +39,8 @@ def main():
     results = get_recon_metrics(
         input_np,
         gt_np,
+        compute_precision=True,
+        compute_recall=False,
         save_error_cloud_dir=error_cloud_dir,
     )
     logging.info(f"Metrics for {args.input_cloud.stem}:\n{json.dumps(results, indent=2)}")

--- a/scripts/eval_cloud.py
+++ b/scripts/eval_cloud.py
@@ -1,22 +1,53 @@
+"""Evaluate a single reconstructed cloud against a GT cloud and print/save metrics."""
+
+import argparse
+import json
+import logging
 from pathlib import Path
 
 import numpy as np
 import open3d as o3d
 
-from oxspires_tools.eval import save_error_cloud
+from oxspires_tools.eval import get_recon_metrics
+from oxspires_tools.utils import setup_logging
 
 
-def evaluate_cloud(input_cloud_path, gt_cloud_path):
-    gt_cloud = o3d.io.read_point_cloud(str(gt_cloud_path))
-    input_cloud = o3d.io.read_point_cloud(str(input_cloud_path))
-    save_error_cloud_path = str(Path(input_cloud_path).with_name(f"{Path(input_cloud_path).stem}_error.ply"))
-    input_cloud_np = np.array(input_cloud.points)
-    gt_cloud_np = np.array(gt_cloud.points)
-    save_error_cloud(input_cloud_np, gt_cloud_np, save_error_cloud_path)
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_cloud", type=Path, required=True, help="Input cloud (.pcd or .ply)")  # fmt: skip
+    parser.add_argument("--gt_cloud", type=Path, required=True, help="GT cloud (.pcd or .ply)")  # fmt: skip
+    parser.add_argument("--output_json", type=Path, default=None, help="Output JSON for metrics")  # fmt: skip
+    parser.add_argument("--output_error_cloud_dir", type=Path, default=None, help="Directory to save error cloud; defaults to <output_json parent>/<stem>_error/ if --output_json is set")  # fmt: skip
+    return parser.parse_args()
+
+
+def main():
+    setup_logging()
+    args = get_args()
+    logging.info(f"Loading input: {args.input_cloud}")
+    input_np = np.asarray(o3d.io.read_point_cloud(str(args.input_cloud)).points)
+    logging.info(f"Loading GT:    {args.gt_cloud}")
+    gt_np = np.asarray(o3d.io.read_point_cloud(str(args.gt_cloud)).points)
+    logging.info(f"  Input: {len(input_np)} points, GT: {len(gt_np)} points")
+
+    error_cloud_dir = args.output_error_cloud_dir
+    if error_cloud_dir is None and args.output_json is not None:
+        error_cloud_dir = args.output_json.parent / (args.output_json.stem + "_error")
+    if error_cloud_dir is not None:
+        error_cloud_dir.mkdir(parents=True, exist_ok=True)
+
+    results = get_recon_metrics(
+        input_np,
+        gt_np,
+        save_error_cloud_dir=error_cloud_dir,
+    )
+    logging.info(f"Metrics for {args.input_cloud.stem}:\n{json.dumps(results, indent=2)}")
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=2)
+        logging.info(f"Saved metrics to {args.output_json}")
 
 
 if __name__ == "__main__":
-    gt_cloud_path = "/home/yifu/workspace/T-RO_2025/2024-03-18-chch-4/rtc_gt_colmap_frame.ply"
-    input_cloud_path = "/home/yifu/workspace/T-RO_2025/2024-03-18-chch-4/nerf_rgb_merged.ply"
-
-    evaluate_cloud(input_cloud_path, gt_cloud_path)
+    main()


### PR DESCRIPTION
  - Refactor oxspires_tools/eval.py: separate distance computation from metric aggregation; add max_distance support and save_error_cloud now accepts pre-computed distances
  - Rewrite scripts/eval_cloud.py as a CLI (argparse, JSON output, error cloud dir); add eval_cloud Taskfile task
  - Fix evo imports to use direct symbol imports across trajectory file interfaces