### PR TITLE
feat: add option to run rectified images

### DIFF
--- a/configs/sensor_rect.yaml
+++ b/configs/sensor_rect.yaml
@@ -1,0 +1,32 @@
+sensor:
+  cameras:
+  - label: cam_front
+    topic: /alphasense_driver_ros/cam0/debayered/image_rect/compressed
+    T_cam_lidar_t_xyz_q_xyzw: [0.00035060884033447846, -0.079574053851818, -0.053826061545697405,
+      0.5034725628949727, 0.5003337192107279, -0.4947539264483171, 0.5013981452864594]
+    T_cam_imu_t_xyz_q_xyzw: [-0.0008544600980918986, 0.005115741648037186, -0.06898747851173177,
+      0.0042909719518877815, -0.7085293318962699, 0.705668106144218, 0.0005453193252705428]
+    intrinsics: [532.4239188382905, 532.6874345419984, 701.3267418181717, 571.7953118187404]
+    extra_params: [0.0, 0.0, 0.0, 0.0]
+    image_height: 1080
+    image_width: 1440
+  - label: cam_left
+    topic: /alphasense_driver_ros/cam1/debayered/image_rect/compressed
+    T_cam_lidar_t_xyz_q_xyzw: [3.388762063794015e-05, -0.07994358595369325, -0.05600121569499821,
+      0.005222551021921984, 0.7078744176660065, -0.7063115244548896, 0.0032502610734581453]
+    intrinsics: [529.4124368418851, 528.9770097239797, 717.8761183654739, 545.7544995213225]
+    extra_params: [0.0, 0.0, 0.0, 0.0]
+    image_height: 1080
+    image_width: 1440
+  - label: cam_right
+    topic: /alphasense_driver_ros/cam2/debayered/image_rect/compressed
+    T_cam_lidar_t_xyz_q_xyzw: [-0.0006070783260079121, -0.07992015242752262, -0.054798558347406996,
+      0.7066174394729171, -0.001174547005383393, 0.0015977924498378243, 0.7075930057111628]
+    intrinsics: [531.7615430276197, 532.4733150370854, 690.5429079532489, 530.3331532080047]
+    extra_params: [0.0, 0.0, 0.0, 0.0]
+    image_height: 1080
+    image_width: 1440
+  camera_model: OPENCV
+  camera_fov: 120
+  max_time_diff_camera_and_pose: 0.025
+  T_base_lidar_t_xyz_q_xyzw: [0.0, 0.0, 0.124, 0.0, 0.0, 1.0, 0.0]

--- a/scripts/estimate_rectified_intrinsics.py
+++ b/scripts/estimate_rectified_intrinsics.py
@@ -1,0 +1,56 @@
+"""Estimate rectified (pinhole) intrinsics from a fisheye sensor.yaml and write sensor_rect.yaml."""
+
+import argparse
+import copy
+from pathlib import Path
+
+import cv2
+import numpy as np
+import yaml
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default=None)
+    parser.add_argument("--output", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)  # fmt: skip
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    default_config = Path(__file__).parent.parent / "configs" / "sensor.yaml"
+    config_path = Path(args.config) if args.config else default_config
+    with open(config_path) as f:
+        yaml_data = yaml.safe_load(f)
+
+    assert yaml_data["sensor"]["camera_model"] == "OPENCV_FISHEYE", "Input must be OPENCV_FISHEYE"
+
+    rect_yaml = copy.deepcopy(yaml_data)
+    rect_yaml["sensor"]["camera_model"] = "OPENCV"
+
+    max_fov = 0.0
+    for cam in rect_yaml["sensor"]["cameras"]:
+        fx, fy, cx, cy = cam["intrinsics"]
+        k1, k2, k3, k4 = cam["extra_params"]
+        h, w = cam["image_height"], cam["image_width"]
+
+        K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]], dtype=np.float64)
+        D = np.array([k1, k2, k3, k4], dtype=np.float64)
+        K_rect = cv2.fisheye.estimateNewCameraMatrixForUndistortRectify(K, D, (w, h), np.eye(3), balance=args.balance)
+
+        fx_r, fy_r, cx_r, cy_r = K_rect[0, 0], K_rect[1, 1], K_rect[0, 2], K_rect[1, 2]
+        fov_deg = 2 * np.degrees(np.arctan(np.sqrt((w / 2 / fx_r) ** 2 + (h / 2 / fy_r) ** 2)))
+        max_fov = max(max_fov, fov_deg)
+
+        cam["intrinsics"] = [float(fx_r), float(fy_r), float(cx_r), float(cy_r)]
+        cam["extra_params"] = [0.0, 0.0, 0.0, 0.0]
+        print(f"{cam['label']}: K_rect = {cam['intrinsics']}, fov = {fov_deg:.1f} deg")
+
+    rect_yaml["sensor"]["camera_fov"] = round(max_fov + 2, 1)
+
+    output_path = Path(args.output) if args.output else config_path.parent / "sensor_rect.yaml"
+    with open(output_path, "w") as f:
+        yaml.dump(rect_yaml, f, default_flow_style=None, sort_keys=False)
+    print(f"Written to {output_path}")

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -32,14 +32,14 @@ def get_args():
     return parser.parse_args()
 
 
-def process_cloud_to_depth(pair, *, T_cam_lidar, K, D, w, h, fov_deg, camera_model, depth_factor, euclidean, skip_hpr, output_depth_dir, output_normal_dir, overlay_dir, cam_dir_name):  # fmt: skip
+def process_cloud_to_depth(pair, *, T_cam_base, K, D, w, h, fov_deg, camera_model, depth_factor, euclidean, skip_hpr, output_depth_dir, output_normal_dir, overlay_dir, cam_dir_name):  # fmt: skip
     """Process a single image-pcd pair."""
     image_path, pcd_path, _ = pair
     pcd = o3d.io.read_point_cloud(str(pcd_path))
     if pcd is None or len(pcd.points) == 0:
         logger.warning(f"Skipping {pcd_path}: {'failed to read' if pcd is None else 'empty'}")
         return
-    pcd.transform(T_cam_lidar)
+    pcd.transform(T_cam_base)
     depth, normal = get_depth_from_cloud(pcd, K, D, w, h, fov_deg, camera_model, depth_factor, euclidean, skip_hpr)
     save_projection_outputs(
         depth,
@@ -78,13 +78,12 @@ if __name__ == "__main__":
         logger.info(f"Processing {cam_name} ({cam_dir}) ...")
         K, D, h, w, fov_deg, camera_model = sensor.get_params_for_depth(cam_name, "vilens_slam", None)
         logger.info(f"Fov: {fov_deg}, camera_model: {camera_model}")
-        T_cam_lidar = sensor.tf.get_transform("lidar", cam_name)
-
+        T_cam_base = sensor.tf.get_transform("base", cam_name)
         image_pcd_pairs = list(get_image_pcd_sync_pair(cam_dir, Path(args.clouds_path), ".jpg", max_time_diff))
 
         process = functools.partial(
             process_cloud_to_depth,
-            T_cam_lidar=T_cam_lidar,
+            T_cam_base=T_cam_base,
             K=K,
             D=D,
             w=w,

--- a/scripts/rectify_images.py
+++ b/scripts/rectify_images.py
@@ -1,0 +1,82 @@
+"""Rectify (undistort) fisheye images using a sensor.yaml config."""
+
+import argparse
+import functools
+import logging
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import cv2
+import numpy as np
+import yaml
+from tqdm.auto import tqdm
+
+from oxspires_tools.sensor import Sensor
+from oxspires_tools.utils import setup_logging
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_EXTS = {".jpg", ".jpeg", ".png"}
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Rectify fisheye images using sensor.yaml calibration")
+    parser.add_argument("--cam_dirs", type=str, nargs="+", required=True)
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--config", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)  # fmt: skip
+    parser.add_argument("--num_workers", type=int, default=28)  # fmt: skip
+    return parser.parse_args()
+
+
+def rectify_image(image_path, *, map1, map2, output_dir, cam_dir_name):
+    """Rectify a single image and save to output_dir."""
+    img = cv2.imread(str(image_path))
+    if img is None:
+        logger.warning(f"Failed to read {image_path}")
+        return
+    img_rect = cv2.remap(img, map1, map2, interpolation=cv2.INTER_LINEAR)
+    out_path = output_dir / cam_dir_name / image_path.name
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(out_path), img_rect)
+
+
+if __name__ == "__main__":
+    setup_logging()
+    args = get_args()
+
+    default_config = Path(__file__).parent.parent / "configs" / "sensor.yaml"
+    config_yaml_path = Path(args.config) if args.config else default_config
+    with open(config_yaml_path) as f:
+        yaml_data = yaml.safe_load(f)
+    sensor = Sensor(**yaml_data["sensor"])
+
+    output_dir = Path(args.output_dir)
+    shutil.rmtree(output_dir, ignore_errors=True)
+
+    cam_names = list(sensor.camera_topics_labelled.keys())
+    assert len(args.cam_dirs) == len(cam_names), f"Expected {len(cam_names)} cam_dirs, got {len(args.cam_dirs)}"
+
+    for cam_name, cam_dir in zip(cam_names, args.cam_dirs):
+        cam_dir = Path(cam_dir)
+        logger.info(f"Rectifying {cam_name} ({cam_dir}) ...")
+
+        K, D, h, w, _, _ = sensor.get_params_for_depth(cam_name, "vilens_slam", None)
+        K_rect = cv2.fisheye.estimateNewCameraMatrixForUndistortRectify(K, D, (w, h), np.eye(3), balance=args.balance)
+        map1, map2 = cv2.fisheye.initUndistortRectifyMap(K, D, np.eye(3), K_rect, (w, h), cv2.CV_16SC2)
+        logger.info(f"  K_rect = {K_rect[0, 0]:.1f} {K_rect[1, 1]:.1f} {K_rect[0, 2]:.1f} {K_rect[1, 2]:.1f}")
+
+        image_paths = sorted(p for p in cam_dir.iterdir() if p.suffix.lower() in _SUPPORTED_EXTS)
+        logger.info(f"  {len(image_paths)} images")
+
+        process = functools.partial(
+            rectify_image, map1=map1, map2=map2, output_dir=output_dir, cam_dir_name=cam_dir.name
+        )
+        with ThreadPoolExecutor(max_workers=args.num_workers) as executor:
+            futures = [executor.submit(process, p) for p in image_paths]
+            pbar = tqdm(total=len(futures), desc=cam_name)
+            for future in as_completed(futures):
+                future.result()
+                pbar.update(1)
+            pbar.close()


### PR DESCRIPTION
- Add scripts/rectify_images.py to rectify images using a pinhole model, scripts/estimate_rectified_intrinsics.py to compute the target intrinsics, and configs/sensor_rect.yaml for rectification 

- config. Extend generate_depth.py with a --rectified option to run depth generation on rectified images.
